### PR TITLE
Publishing to Sonatype OSS

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,7 @@
 version: 2
 jobs:
   build:
+    context: OSS
     working_directory: ~/repo
     docker:
       - image: circleci/openjdk:8-jdk

--- a/buildSrc/src/main/kotlin/publishing.kt
+++ b/buildSrc/src/main/kotlin/publishing.kt
@@ -26,7 +26,7 @@ private object Remote {
     val url = "https://oss.sonatype.org/service/local/staging/deploy/maven2"
 }
 
-fun PublishingExtension.withRemote(version: Any) {
+fun PublishingExtension.publishReleasesToRemote(version: Any) {
     if (!version.toString().endsWith("-SNAPSHOT")) {
         repositories {
             maven {

--- a/buildSrc/src/main/kotlin/publishing.kt
+++ b/buildSrc/src/main/kotlin/publishing.kt
@@ -1,0 +1,63 @@
+import org.gradle.api.Project
+import org.gradle.api.publish.PublishingExtension
+import org.gradle.api.publish.maven.MavenPublication
+import org.gradle.kotlin.dsl.configure
+import org.gradle.plugins.signing.SigningExtension
+
+private object Gpg {
+    val key by lazy {
+        System.getenv("GPG_KEY")
+    }
+
+    val password by lazy {
+        System.getenv("GPG_PASSWORD")
+    }
+}
+
+private object Remote {
+    val username by lazy {
+        System.getenv("OSSRH_USERNAME")
+    }
+
+    val password by lazy {
+        System.getenv("OSSRH_PASSWORD")
+    }
+
+    val url = "https://oss.sonatype.org/service/local/staging/deploy/maven2"
+}
+
+fun PublishingExtension.withRemote(version: Any) {
+    if (!version.toString().endsWith("-SNAPSHOT")) {
+        repositories {
+            maven {
+                name = "remote"
+                setUrl(Remote.url)
+                credentials {
+                    username = Remote.username
+                    password = Remote.password
+                }
+            }
+        }
+    }
+}
+
+fun MavenPublication.standardPom() {
+    pom {
+        scm {
+            url.set("https://github.com/open-toast/gummy-bears")
+        }
+        licenses {
+            license {
+                name.set("The Apache License, Version 2.0")
+                url.set("http://www.apache.org/licenses/LICENSE-2.0.txt")
+            }
+        }
+    }
+}
+
+fun Project.sign(publication: MavenPublication) {
+    configure<SigningExtension> {
+        useInMemoryPgpKeys(Gpg.key, Gpg.password)
+        sign(publication)
+    }
+}

--- a/buildSrc/src/main/kotlin/publishing.kt
+++ b/buildSrc/src/main/kotlin/publishing.kt
@@ -4,13 +4,13 @@ import org.gradle.api.publish.maven.MavenPublication
 import org.gradle.kotlin.dsl.configure
 import org.gradle.plugins.signing.SigningExtension
 
-private object Gpg {
+private object Pgp {
     val key by lazy {
-        System.getenv("GPG_KEY")
+        System.getenv("PGP_KEY")
     }
 
     val password by lazy {
-        System.getenv("GPG_PASSWORD")
+        System.getenv("PGP_PASSWORD")
     }
 }
 
@@ -57,7 +57,7 @@ fun MavenPublication.standardPom() {
 
 fun Project.sign(publication: MavenPublication) {
     configure<SigningExtension> {
-        useInMemoryPgpKeys(Gpg.key, Gpg.password)
+        useInMemoryPgpKeys(Pgp.key, Pgp.password)
         sign(publication)
     }
 }

--- a/buildSrc/src/main/kotlin/signatures.kt
+++ b/buildSrc/src/main/kotlin/signatures.kt
@@ -115,7 +115,7 @@ fun Project.buildSignatures(
                 })
             }
 
-            withRemote(version)
+            publishReleasesToRemote(version)
         }
     }
 }

--- a/buildSrc/src/main/kotlin/signatures.kt
+++ b/buildSrc/src/main/kotlin/signatures.kt
@@ -47,6 +47,7 @@ fun Project.buildSignatures(
     apply(plugin = "maven-publish")
     apply(plugin = "ru.vyarus.animalsniffer")
     apply(plugin = "de.undercouch.download")
+    apply(plugin = "signing")
 
     configurations {
         create(scopes.sugar)
@@ -101,7 +102,7 @@ fun Project.buildSignatures(
 
         configure<PublishingExtension> {
             publications {
-                create<MavenPublication>("signature") {
+                sign(create<MavenPublication>("signature") {
                     groupId = "${project.group}"
                     version = "${project.version}"
                     artifactId = "gummy-bears-api-$apiLevel"
@@ -109,29 +110,12 @@ fun Project.buildSignatures(
                         extension = "signature"
                         builtBy(tasks.named("animalsnifferSignature"))
                     }
-                }
+
+                    standardPom()
+                })
             }
 
-            val remoteUrl = project.properties[
-                if (version.toString().endsWith("-SNAPSHOT")) {
-                    "publish.remote.url.snapshots"
-                } else {
-                    "publish.remote.url.releases"
-                }
-            ] as String?
-
-            repositories {
-                if (remoteUrl != null) {
-                    maven {
-                        name = "remote"
-                        setUrl(remoteUrl)
-                        credentials {
-                            username = properties["artifactory_user"] as String
-                            password = properties["artifactory_password"] as String
-                        }
-                    }
-                }
-            }
+            withRemote(version)
         }
     }
 }


### PR DESCRIPTION
This sets up signing of artifacts and publishing to the staging Sonatype OSS repo. The necessary credentials are provided via CircleCI context/environment variables.