### PR TITLE
Add publish step and other CircleCI tuning

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,11 @@ jobs:
 
     steps:
       - checkout
-
-      # run tests!
-      - run: gradle check
+      - run: ./gradlew check
+      - when:
+          condition:
+            branches:
+              only:
+                - master
+          steps:
+            - run: ./gradlew publish

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-version: 2
+version: 2.1
 jobs:
   build:
     context: OSS

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,4 +35,7 @@ jobs:
             - build/sdk-archives
           key: v1-sdk-cache-{{ checksum "build.gradle.kts" }}
 
-      - run: "[[ \"$CIRCLE_BRANCH\" == master ]] && ./gradlew publish"
+      - store_test_results:
+          path: build/test-results
+
+      - run: "[[ \"$CIRCLE_BRANCH\" == master ]] && ./gradlew publish || echo skipping publishing"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,9 +12,5 @@ jobs:
 
     steps:
       - checkout
-      - run: 
-          name: build and test
-          command: ./gradlew check
-      - run:
-          name: publish release
-          command: [[ "$CIRCLE_BRANCH" == "master" ]] && ./gradlew publish
+      - run: ./gradlew check
+      - run: "[[ \"$CIRCLE_BRANCH\" == master ]] && ./gradlew publish"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-version: 2.1
+version: 2.0
 jobs:
   build:
     context: OSS
@@ -12,11 +12,13 @@ jobs:
 
     steps:
       - checkout
-      - run: ./gradlew check
-      - when:
-          condition:
+      - run: 
+          name: build and test
+          command: ./gradlew check
+      - run: 
+          name: publish release
+          command: ./gradlew publish
+          when:
             branches:
               only:
                 - master
-          steps:
-            - run: ./gradlew publish

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,5 +12,27 @@ jobs:
 
     steps:
       - checkout
+
+      - restore_cache:
+          key: v1-gradle-wrapper-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}
+      - restore_cache:
+          key: v1-gradle-cache-{{ checksum "build.gradle.kts" }}
+      - restore_cache:
+          key: v1-sdk-cache-{{ checksum "build.gradle.kts" }}
+
       - run: ./gradlew check
+
+      - save_cache:
+          paths:
+            - ~/.gradle/wrapper
+          key: v1-gradle-wrapper-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}
+      - save_cache:
+          paths:
+            - ~/.gradle/caches
+          key: v1-gradle-cache-{{ checksum "build.gradle.kts" }}
+      - save_cache:
+          paths:
+            - build/sdk-archives
+          key: v1-sdk-cache-{{ checksum "build.gradle.kts" }}
+
       - run: "[[ \"$CIRCLE_BRANCH\" == master ]] && ./gradlew publish"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
-version: 2.1
+version: 2.0
 jobs:
   build:
-    # context: OSS
+    context: OSS
     working_directory: ~/repo
     docker:
       - image: circleci/openjdk:8-jdk
@@ -12,8 +12,9 @@ jobs:
 
     steps:
       - checkout
-      - run: ./gradlew check
-      - when:
-          condition: << pipeline.git.branch	>> == master
-          steps:
-            - run: ./gradlew publish
+      - run: 
+          name: build and test
+          command: ./gradlew check
+      - run:
+          name: publish release
+          command: [[ "$CIRCLE_BRANCH" == "master" ]] && ./gradlew publish

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
-version: 2.0
+version: 2.1
 jobs:
   build:
-    context: OSS
+    # context: OSS
     working_directory: ~/repo
     docker:
       - image: circleci/openjdk:8-jdk
@@ -12,13 +12,10 @@ jobs:
 
     steps:
       - checkout
-      - run: 
-          name: build and test
-          command: ./gradlew check
-      - run: 
-          name: publish release
-          command: ./gradlew publish
-          when:
+      - run: ./gradlew check
+      - when:
+          condition:
             branches:
-              only:
-                - master
+              only: master
+          steps:
+            - run: ./gradlew publish

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,6 @@ jobs:
       - checkout
       - run: ./gradlew check
       - when:
-          condition: << pipeline.git.branch	== master >>
+          condition: << pipeline.git.branch	>> == master
           steps:
             - run: ./gradlew publish

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,8 +14,6 @@ jobs:
       - checkout
       - run: ./gradlew check
       - when:
-          condition:
-            branches:
-              only: master
+          condition: << pipeline.git.branch	== master >>
           steps:
             - run: ./gradlew publish

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,7 +25,7 @@ plugins {
     kotlin("jvm") version versions.kotlin apply false
 }
 
-subprojects {
+allprojects {
     group = "com.toasttab.android"
     version = "0.0.2-SNAPSHOT"
 
@@ -34,3 +34,5 @@ subprojects {
         jcenter()
     }
 }
+
+promoteStagingRepo()

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -25,4 +25,5 @@ plugins {
 dependencies {
     implementation("de.undercouch:gradle-download-task:4.0.2")
     implementation("ru.vyarus:gradle-animalsniffer-plugin:1.5.0")
+    implementation("io.codearte.gradle.nexus:gradle-nexus-staging-plugin:0.21.2")
 }

--- a/buildSrc/src/main/kotlin/publishing.kt
+++ b/buildSrc/src/main/kotlin/publishing.kt
@@ -1,8 +1,11 @@
 import org.gradle.api.Project
 import org.gradle.api.publish.PublishingExtension
 import org.gradle.api.publish.maven.MavenPublication
+import org.gradle.kotlin.dsl.apply
 import org.gradle.kotlin.dsl.configure
 import org.gradle.plugins.signing.SigningExtension
+
+import io.codearte.gradle.nexus.NexusStagingExtension
 
 private object Pgp {
     val key by lazy {
@@ -59,5 +62,14 @@ fun Project.sign(publication: MavenPublication) {
     configure<SigningExtension> {
         useInMemoryPgpKeys(Pgp.key, Pgp.password)
         sign(publication)
+    }
+}
+
+fun Project.promoteStagingRepo() {
+    apply(plugin = "io.codearte.nexus-staging")
+
+    configure<NexusStagingExtension> {
+        username = Remote.username
+        password = Remote.password
     }
 }

--- a/buildSrc/src/main/kotlin/signatures.kt
+++ b/buildSrc/src/main/kotlin/signatures.kt
@@ -72,13 +72,13 @@ fun Project.buildSignatures(
         dependsOn(":sugar:build")
         dependsOn(":test:sugar-calls:build")
 
-        reports {
-            junitXml.destination = file("${rootProject.buildDir}/test-results")
-        }
-
         systemProperty("sdk", sdk)
         systemProperty("jar", configurations.getByName(scopes.sugarCalls).asPath)
         systemProperty("dexout", project.buildDir)
+
+        reports {
+            junitXml.destination = file("${rootProject.buildDir}/test-results")
+        }
     }
 
     configure<ru.vyarus.gradle.plugin.animalsniffer.signature.AnimalSnifferSignatureExtension> {

--- a/buildSrc/src/main/kotlin/signatures.kt
+++ b/buildSrc/src/main/kotlin/signatures.kt
@@ -65,7 +65,7 @@ fun Project.buildSignatures(
         add("testImplementation", libraries.truth)
     }
 
-    val sdk = project.file("${rootProject.buildDir}/sdk/$sdkDir/android.jar")
+    val sdk = project.file("$buildDir/sdk/$sdkDir/android.jar")
 
     tasks.withType<Test> {
         dependsOn("unpackSdk")
@@ -86,12 +86,12 @@ fun Project.buildSignatures(
         tempAndMove(true)
         onlyIfModified(true)
         src("https://dl.google.com/android/repository/$sdkFile")
-        dest("$buildDir/$sdkFile")
+        dest("${rootProject.buildDir}/sdk-archives/$sdkFile")
     }
 
     tasks.register<Copy>(downloadTasks.unpack) {
         dependsOn(downloadTasks.download)
-        from(zipTree("$buildDir/$sdkFile"))
+        from(zipTree("${rootProject.buildDir}/sdk-archives/$sdkFile"))
         into("$buildDir/sdk")
     }
 

--- a/buildSrc/src/main/kotlin/signatures.kt
+++ b/buildSrc/src/main/kotlin/signatures.kt
@@ -72,6 +72,10 @@ fun Project.buildSignatures(
         dependsOn(":sugar:build")
         dependsOn(":test:sugar-calls:build")
 
+        reports {
+            junitXml.destination = file("${rootProject.buildDir}/test-results")
+        }
+
         systemProperty("sdk", sdk)
         systemProperty("jar", configurations.getByName(scopes.sugarCalls).asPath)
         systemProperty("dexout", project.buildDir)

--- a/buildSrc/src/main/kotlin/signatures.kt
+++ b/buildSrc/src/main/kotlin/signatures.kt
@@ -65,7 +65,7 @@ fun Project.buildSignatures(
         add("testImplementation", libraries.truth)
     }
 
-    val sdk = project.file("$buildDir/sdk/$sdkDir/android.jar")
+    val sdk = project.file("${rootProject.buildDir}/sdk/$sdkDir/android.jar")
 
     tasks.withType<Test> {
         dependsOn("unpackSdk")


### PR DESCRIPTION
* Add a conditional publish step (only master branch, gradle build will only publish release artifacts)
* Add caching (gradle wrapper, dependencies, android sdk zipfiles)
* Store test results
* Configure auto-promotion of Sonatype OSS staging repo