### PR TITLE
Derive version from tag, deploy on tag push

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,27 +1,24 @@
 version: 2.1
 
-jobs:
-  build:
-    working_directory: ~/repo
+executors:
+  builder:
+    working_directory: ~/code
     docker:
-      - image: circleci/openjdk:8-jdk
-
+      - image: cimg/openjdk:8.0
     environment:
-      JVM_OPTS: -Xmx3200m
-      TERM: dumb
+      JAVA_OPTS: "-Xmx3200m"
+      GRADLE_OPTS: "-Dorg.gradle.daemon=false"
 
+commands:
+  read_cache:
     steps:
-      - checkout
-
       - restore_cache:
           key: v1-gradle-wrapper-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}
       - restore_cache:
           key: v1-gradle-cache-{{ checksum "build.gradle.kts" }}
 
-      - run:
-          name: Build and test
-          command: ./gradlew check
-
+  write_cache:
+    steps:
       - save_cache:
           paths:
             - ~/.gradle/wrapper
@@ -31,6 +28,19 @@ jobs:
             - ~/.gradle/caches
           key: v1-gradle-cache-{{ checksum "build.gradle.kts" }}
 
+jobs:
+  build:
+    executor: builder
+    steps:
+      - checkout
+      - read_cache
+
+      - run:
+          name: Build and test
+          command: ./gradlew check
+
+      - write_cache
+
       - run:
           name: Save test results
           command: |
@@ -38,21 +48,28 @@ jobs:
             find . -type f -regex ".*/build/test-results/.*xml" -exec cp {} ~/test-results/junit/ \;
           when: always
 
-      - store_test_results:
-          path: ~/test-results
-      - store_artifacts:
-          path: ~/test-results/junit
-
       - run:
           name: Deploy locally
           command: ./gradlew publishToMavenLocal
+
+  release:
+    executor: builder
+    steps:
+      - checkout
+      - read_cache
       - run:
-          name: Deploy (if release)
-          command: "if [[ \"$CIRCLE_BRANCH\" == master ]]; then ./gradlew publish closeAndReleaseRepository -Dorg.gradle.internal.http.socketTimeout=120000 -Dorg.gradle.internal.network.retry.max.attempts=1 -Dorg.gradle.internal.publish.checksums.insecure=true; else echo skipping publishing; fi"
+          name: Publish release
+          command: "./gradlew publishToRemote closeAndReleaseRepository publishPlugins -Dorg.gradle.internal.http.socketTimeout=120000 -Dorg.gradle.internal.network.retry.max.attempts=1 -Dorg.gradle.internal.publish.checksums.insecure=true"
 
 workflows:
   version: 2.1
   build:
     jobs:
-      - build:
+      - build
+      - release:
           context: OSS
+          filters:
+            tags:
+              only: /^\d+\.\d+\.\d+$/
+            branches:
+              ignore: /.*/

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,9 +25,9 @@ plugins {
     kotlin("jvm") version versions.kotlin apply false
 }
 
-allprojects {
+subprojects {
     group = "com.toasttab.android"
-    version = "0.4.0-SNAPSHOT"
+    version = rootProject.version
 
     repositories {
         google()

--- a/buildSrc/src/main/kotlin/dependencies.kt
+++ b/buildSrc/src/main/kotlin/dependencies.kt
@@ -18,7 +18,7 @@ object versions {
     const val clikt = "3.0.1"
     const val desugarJdkLibs = "1.0.10"
     const val r8 = "1.5.68"
-    const val kotlin = "1.4.10"
+    const val kotlin = "1.4.21"
     const val javapoet = "1.11.1"
     const val javassist = "3.26.0-GA"
     const val junit = "4.12"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -13,6 +13,17 @@
  * limitations under the License.
  */
 
+buildscript {
+    repositories {
+        gradlePluginPortal()
+    }
+    dependencies {
+        classpath("gradle.plugin.net.vivin:gradle-semantic-build-versioning:4.0.0")
+    }
+}
+
+apply(plugin = "net.vivin.gradle-semantic-build-versioning")
+
 rootProject.name = "gummybears"
 
 include(


### PR DESCRIPTION
* Use the semantic versioning plugin to version based on the last tag.
* Extract artifact publishing into a separate job that runs on tag push
* Use a next-generation build image (cimg)
