### PR TITLE
Fixed Maven pom example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ dependencies {
     <version>1.22</version>
     <configuration>
         <signature>
-            <groupId>com.toasttab</groupId>
+            <groupId>com.toasttab.android</groupId>
             <artifactId>gummy-bears-api-21</artifactId>
             <version>0.5.0</version>
         </signature>


### PR DESCRIPTION
The maven pom.xml example is missing part of the groupId:

`<groupId>com.toasttab</groupId>` should be `<groupId>com.toasttab.android</groupId>`
