### PR TITLE
Ensure that serialized signatures use HashSets

### DIFF
--- a/api/19/src/test/java/com/toasttab/android/Api19SignaturesTest.kt
+++ b/api/19/src/test/java/com/toasttab/android/Api19SignaturesTest.kt
@@ -17,11 +17,6 @@ package com.toasttab.android
 
 import org.codehaus.mojo.animal_sniffer.Clazz
 import org.junit.Test
-import protokt.v1.toasttab.expediter.v1.AccessDeclaration
-import protokt.v1.toasttab.expediter.v1.AccessProtection
-import protokt.v1.toasttab.expediter.v1.MemberDescriptor
-import protokt.v1.toasttab.expediter.v1.SymbolicReference
-import protokt.v1.toasttab.expediter.v1.TypeDescriptors
 import strikt.api.expectThat
 import strikt.assertions.all
 import strikt.assertions.contains

--- a/api/19/src/test/java/com/toasttab/android/Api19SignaturesTest.kt
+++ b/api/19/src/test/java/com/toasttab/android/Api19SignaturesTest.kt
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2023. Toast Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.toasttab.android
+
+import org.codehaus.mojo.animal_sniffer.Clazz
+import org.junit.Test
+import protokt.v1.toasttab.expediter.v1.AccessDeclaration
+import protokt.v1.toasttab.expediter.v1.AccessProtection
+import protokt.v1.toasttab.expediter.v1.MemberDescriptor
+import protokt.v1.toasttab.expediter.v1.SymbolicReference
+import protokt.v1.toasttab.expediter.v1.TypeDescriptors
+import strikt.api.expectThat
+import strikt.assertions.all
+import strikt.assertions.contains
+import strikt.assertions.isA
+import strikt.assertions.isNotNull
+import java.io.File
+import java.io.ObjectInputStream
+import java.util.zip.GZIPInputStream
+
+class Api19SignaturesTest {
+    @Test
+    fun `signatures include Integer#hashCode(int)`() {
+        val desc = ObjectInputStream(GZIPInputStream(File(System.getProperty("signatures")).inputStream())).use {
+            generateSequence { it.readObject() as Clazz? }.toList()
+        }
+
+        val integer = desc.find { it.name == "java/lang/Integer" }
+
+        expectThat(integer).isNotNull().and {
+            get { signatures }.contains("hashCode(I)I")
+        }
+    }
+
+    @Test
+    fun `core lib signatures include Stream#count()`() {
+        val desc = ObjectInputStream(GZIPInputStream(File(System.getProperty("coreLibSignatures")).inputStream())).use {
+            generateSequence { it.readObject() as Clazz? }.toList()
+        }
+
+        val stream = desc.find { it.name == "java/util/stream/Stream" }
+
+        expectThat(stream).isNotNull().and {
+            get { signatures }.contains("count()J")
+        }
+    }
+
+    @Test
+    fun `signatures use HashSet`() {
+        val desc = ObjectInputStream(GZIPInputStream(File(System.getProperty("signatures")).inputStream())).use {
+            generateSequence { it.readObject() as Clazz? }.toList()
+        }
+
+        expectThat(desc).all {
+            get { signatures }.isA<HashSet<*>>()
+        }
+    }
+
+    @Test
+    fun `core lib signatures use HashSet`() {
+        val desc = ObjectInputStream(GZIPInputStream(File(System.getProperty("coreLibSignatures")).inputStream())).use {
+            generateSequence { it.readObject() as Clazz? }.toList()
+        }
+
+        expectThat(desc).all {
+            get { signatures }.isA<HashSet<*>>()
+        }
+    }
+}

--- a/buildSrc/src/main/kotlin/signatures-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/signatures-conventions.gradle.kts
@@ -65,6 +65,7 @@ dependencies {
     testImplementation(libs.strikt.core)
     testImplementation(libs.expediter.core)
     testImplementation(libs.protobuf.java)
+    testImplementation(libs.animalSniffer)
 }
 
 tasks.register<TypeDescriptorsTask>(Tasks.signatures) {
@@ -91,6 +92,7 @@ publishing.publications.named<MavenPublication>(Publications.MAIN) {
 tasks {
     test {
         fileProperty("platformDescriptors", layout.buildDirectory.file(Outputs.expediter))
+        fileProperty("signatures", layout.buildDirectory.file(Outputs.signatures))
         filesProperty("sdk", configurations.named(Configurations.SDK))
         filesProperty("jar", configurations.named(Configurations.EXERCISE_STANDARD_SUGAR))
 

--- a/buildSrc/src/main/kotlin/signatures-core-lib-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/signatures-core-lib-conventions.gradle.kts
@@ -55,6 +55,7 @@ publishing.publications.named<MavenPublication>(Publications.MAIN) {
 tasks {
     test {
         fileProperty("platformCoreLibDescriptors", layout.buildDirectory.file(Outputs.expediterCoreLib))
+        fileProperty("coreLibSignatures", layout.buildDirectory.file(Outputs.signaturesCoreLib))
 
         dependsOn(Tasks.signaturesCoreLib)
     }

--- a/signature-builder/src/main/kotlin/com/toasttab/android/descriptors/sniffer/AnimalSnifferConverter.kt
+++ b/signature-builder/src/main/kotlin/com/toasttab/android/descriptors/sniffer/AnimalSnifferConverter.kt
@@ -22,7 +22,7 @@ import protokt.v1.toasttab.expediter.v1.TypeDescriptor
 object AnimalSnifferConverter {
     fun convert(type: TypeDescriptor) = Clazz(
         type.name,
-        (type.fields.map(AnimalSnifferConverter::fieldSignature) + type.methods.map(AnimalSnifferConverter::methodSignature)).toSet(),
+        (type.fields.map(AnimalSnifferConverter::fieldSignature) + type.methods.map(AnimalSnifferConverter::methodSignature)).toHashSet(),
         type.superName,
         type.interfaces.toTypedArray()
     )


### PR DESCRIPTION
Because Animal Sniffer signatures are serialized using Java Serialization, we need to make sure that the types embedded into the signatures are available on the classpath when Animal Sniffer is run. Specifically, for Clazz.signatures, when the set is empty, Kotlin's toSet method will return a kotlin.collections.EmptySet. This change ensures that a plain HashSet is always used.

Fixes https://github.com/open-toast/gummy-bears/issues/23.