### PR TITLE
Recognize that `compareUnsigned` is safe on `Byte` and `Short`.

### DIFF
--- a/sugar/basic/src/main/java/desugar/java/lang/DesugarByte.java
+++ b/sugar/basic/src/main/java/desugar/java/lang/DesugarByte.java
@@ -1,6 +1,10 @@
 package desugar.java.lang;
 
 public final class DesugarByte {
+    public static int compareUnsigned(byte x, byte y) {
+        throw new RuntimeException();
+    }
+
     public static int hashCode(byte i) {
         throw new RuntimeException();
     }

--- a/sugar/basic/src/main/java/desugar/java/lang/DesugarShort.java
+++ b/sugar/basic/src/main/java/desugar/java/lang/DesugarShort.java
@@ -1,6 +1,10 @@
 package desugar.java.lang;
 
 public final class DesugarShort {
+    public static int compareUnsigned(short x, short y) {
+        throw new RuntimeException();
+    }
+
     public static int hashCode(short i) {
         throw new RuntimeException();
     }


### PR DESCRIPTION
They have been always desugared since
https://r8.googlesource.com/r8/+/4b8c252dbd34d0b8d1d5defe7bbe5da288eed677,
which came shortly after support for `Long` and `Integer`,
https://r8.googlesource.com/r8/+/62ef970fea988efa2bbfc81e68d1072d5ab930d7,
which is already recognized by Gummy Bears.
