### PR TITLE
Filtering coreLib types based on config lint files

### DIFF
--- a/api/19/src/test/java/com/toasttab/android/Api19TypeDescriptorsTest.kt
+++ b/api/19/src/test/java/com/toasttab/android/Api19TypeDescriptorsTest.kt
@@ -112,29 +112,39 @@ class Api19TypeDescriptorsTest {
     }
 
     /**
-     * Tests an edge case in merging type descriptors, where multiple versions of `LinuxFileSystemProvider` are provided,
-     * one extending `UnixFileSystemProvider` and another extending `FileSystem`
+     * Standard desugared methods (from DesugarInteger etc.) must be preserved in coreLib
+     * signatures even when lint file filtering is applied.
      */
     @Test
-    fun `core lib v2 LinuxFileSystemProvider extends UnixFileSystemProvider`() {
-        val provider = coreLibDescriptors2.types.find { it.name == "sun/nio/fs/LinuxFileSystemProvider" }
+    fun `core lib v2 type descriptors include Integer#hashCode(int)`() {
+        val integer = coreLibDescriptors2.types.find { it.name == "java/lang/Integer" }
 
-        expectThat(provider).isNotNull().and {
-            get { superName }.isEqualTo("sun/nio/fs/UnixFileSystemProvider")
+        expectThat(integer).isNotNull().and {
+            get { methods }.contains(
+                MemberDescriptor {
+                    ref =
+                        SymbolicReference {
+                            name = "hashCode"
+                            signature = "(I)I"
+                        }
+                    protection = AccessProtection.PUBLIC
+                    declaration = AccessDeclaration.STATIC
+                },
+            )
         }
     }
 
     /**
-     * Tests an edge case in merging type descriptors, where multiple versions of `MimeTypesFileTypeDetector` are
-     * provided, one with the transformed `desugar/sun/nio/fs/DesugarAbstractFileTypeDetector` name
+     * Internal `sun/nio/fs` classes from the coreLib JAR are excluded by the lint file filter
+     * because they are not public desugared APIs.
      */
     @Test
-    fun `core lib v2 MimeTypesFileTypeDetector extends AbstractFileTypeDetector`() {
+    fun `core lib v2 excludes internal sun nio fs classes`() {
+        val provider = coreLibDescriptors2.types.find { it.name == "sun/nio/fs/LinuxFileSystemProvider" }
         val detector = coreLibDescriptors2.types.find { it.name == "sun/nio/fs/MimeTypesFileTypeDetector" }
 
-        expectThat(detector).isNotNull().and {
-            get { superName }.isEqualTo("sun/nio/fs/AbstractFileTypeDetector")
-        }
+        expectThat(provider).isEqualTo(null)
+        expectThat(detector).isEqualTo(null)
     }
 
     /**

--- a/api/21/src/test/java/com/toasttab/android/Api21TypeDescriptorsTest.kt
+++ b/api/21/src/test/java/com/toasttab/android/Api21TypeDescriptorsTest.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2026. Toast Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.toasttab.android
+
+import org.junit.jupiter.api.Test
+import protokt.v1.toasttab.expediter.v1.TypeDescriptors
+import strikt.api.expectThat
+import strikt.assertions.isEqualTo
+import strikt.assertions.isNotNull
+import java.io.File
+import java.util.zip.GZIPInputStream
+
+class Api21TypeDescriptorsTest {
+    companion object {
+        private fun descriptors(name: String) =
+            GZIPInputStream(File(System.getProperty(name)).inputStream()).use {
+                TypeDescriptors.deserialize(it)
+            }
+
+        private val coreLibDescriptors2 by lazy {
+            descriptors("platformCoreLibDescriptors2")
+        }
+    }
+
+    /**
+     * CompletableFuture is present in the desugar_jdk_libs JAR but is not a desugared API —
+     * it is not listed in the lint file and crashes at runtime on API 21.
+     * The lint file filter must exclude it from the signature.
+     */
+    @Test
+    fun `core lib v2 excludes CompletableFuture`() {
+        val completableFuture = coreLibDescriptors2.types.find { it.name == "java/util/concurrent/CompletableFuture" }
+
+        expectThat(completableFuture).isEqualTo(null)
+    }
+
+    /**
+     * Optional is a fully desugared class listed in the lint file and should be present.
+     */
+    @Test
+    fun `core lib v2 includes Optional`() {
+        val optional = coreLibDescriptors2.types.find { it.name == "java/util/Optional" }
+
+        expectThat(optional).isNotNull()
+    }
+}

--- a/buildSrc/src/main/kotlin/Common.kt
+++ b/buildSrc/src/main/kotlin/Common.kt
@@ -20,6 +20,7 @@ object Configurations {
     const val GENERATED_CALLERS = "_generated_callers_"
     const val CORE_LIB = "_core_lib_"
     const val CORE_LIB_2 = "_core_lib_2_"
+    const val CORE_LIB_CONFIG_2 = "_core_lib_config_2_"
 }
 
 object Publications {

--- a/buildSrc/src/main/kotlin/LintFileSelector.kt
+++ b/buildSrc/src/main/kotlin/LintFileSelector.kt
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2026. Toast Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import java.io.File
+import java.util.zip.ZipFile
+
+object LintFileSelector {
+    private val LINT_FILE_PATTERN = Regex("""desugared_apis_(\d+)_(\d+)\.txt""")
+
+    /**
+     * Represents a parsed lint file with its compileSdk and minSdk thresholds.
+     */
+    private data class LintFileCandidate(
+        val file: File,
+        val compileSdk: Int,
+        val minSdk: Int,
+    )
+
+    /**
+     * Extracts lint files from a `desugar_jdk_libs_configuration` JAR and selects the best one
+     * for the given API level. Mirrors Android Gradle Plugin's selection logic:
+     * 1. Pick the highest compileSdk directory available.
+     * 2. Within that, pick the lint file with the highest minSdk threshold that does not exceed
+     *    the target API level.
+     *
+     * @param configJar the `desugar_jdk_libs_configuration` JAR file
+     * @param apiLevel the target Android API level (minSdk)
+     * @param outputDir directory to extract lint files into
+     * @return the selected lint file, or null if no matching lint file was found
+     */
+    fun selectLintFile(configJar: File, apiLevel: Int, outputDir: File): File? {
+        outputDir.mkdirs()
+
+        val candidates = mutableListOf<LintFileCandidate>()
+
+        ZipFile(configJar).use { zip ->
+            for (entry in zip.entries()) {
+                if (entry.isDirectory) continue
+
+                val match = LINT_FILE_PATTERN.find(entry.name) ?: continue
+                val compileSdk = match.groupValues[1].toInt()
+                val minSdk = match.groupValues[2].toInt()
+
+                val outFile = File(outputDir, entry.name)
+                outFile.parentFile.mkdirs()
+                zip.getInputStream(entry).use { input ->
+                    outFile.outputStream().use { output ->
+                        input.copyTo(output)
+                    }
+                }
+
+                candidates.add(LintFileCandidate(outFile, compileSdk, minSdk))
+            }
+        }
+
+        if (candidates.isEmpty()) return null
+
+        val highestCompileSdk = candidates.maxOf { it.compileSdk }
+
+        return candidates
+            .filter { it.compileSdk == highestCompileSdk && it.minSdk <= apiLevel }
+            .maxByOrNull { it.minSdk }
+            ?.file
+    }
+}

--- a/buildSrc/src/main/kotlin/TypeDescriptorsTask.kt
+++ b/buildSrc/src/main/kotlin/TypeDescriptorsTask.kt
@@ -13,12 +13,15 @@
  * limitations under the License.
  */
 
+import LintFileSelector.selectLintFile
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.FileCollection
+import org.gradle.api.provider.Property
 import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Classpath
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
@@ -41,6 +44,29 @@ abstract class TypeDescriptorsTask @Inject constructor(
     @PathSensitive(PathSensitivity.ABSOLUTE)
     lateinit var desugar: FileCollection
 
+    /**
+     * CoreLib desugared JAR(s) to be filtered by the lint file. Passed to the builder
+     * via `--desugared-corelib` so that the lint filter applies only to these JARs.
+     */
+    @get:InputFiles
+    @get:Optional
+    @get:PathSensitive(PathSensitivity.ABSOLUTE)
+    abstract val desugaredCorelib: Property<FileCollection>
+
+    /**
+     * The `desugar_jdk_libs_configuration` JAR containing desugared API lint files.
+     * When set together with [apiLevel], the best lint file is extracted and passed
+     * to the builder to filter coreLib classes to only truly-desugared APIs.
+     */
+    @get:InputFiles
+    @get:Optional
+    @get:PathSensitive(PathSensitivity.NONE)
+    abstract val coreLibConfigJar: Property<FileCollection>
+
+    @get:Input
+    @get:Optional
+    abstract val apiLevel: Property<Int>
+
     @OutputFile
     lateinit var animalSnifferOutput: Any
 
@@ -52,21 +78,48 @@ abstract class TypeDescriptorsTask @Inject constructor(
 
     @TaskAction
     fun exec() {
+        val lintFile = if (coreLibConfigJar.isPresent && apiLevel.isPresent) {
+            selectLintFile(
+                coreLibConfigJar.get().singleFile,
+                apiLevel.get(),
+                temporaryDir
+            )
+        } else {
+            null
+        }
+
         exec.javaexec {
             mainClass.set("com.toasttab.android.descriptors.AndroidTypeDescriptorBuilderKt")
             classpath = this@TypeDescriptorsTask.classpath
 
-            args = listOf(
-                "--sdk",
-                sdk.singleFile.path,
-                "--animal-sniffer-output",
-                project.file(animalSnifferOutput).path,
-                "--expediter-output",
-                project.file(expediterOutput).path,
-                "--description",
-                outputDescription
-            ) + desugar.flatMap {
-                listOf("--desugared", it.path)
+            args = buildList {
+                addAll(
+                    listOf(
+                        "--sdk",
+                        sdk.singleFile.path,
+                        "--animal-sniffer-output",
+                        project.file(animalSnifferOutput).path,
+                        "--expediter-output",
+                        project.file(expediterOutput).path,
+                        "--description",
+                        outputDescription
+                    )
+                )
+                addAll(
+                    desugar.flatMap {
+                        listOf("--desugared", it.path)
+                    }
+                )
+                if (desugaredCorelib.isPresent) {
+                    addAll(
+                        desugaredCorelib.get().flatMap {
+                            listOf("--desugared-corelib", it.path)
+                        }
+                    )
+                }
+                if (lintFile != null) {
+                    addAll(listOf("--lint-file", lintFile.path))
+                }
             }
         }
     }

--- a/buildSrc/src/main/kotlin/signatures-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/signatures-conventions.gradle.kts
@@ -30,6 +30,7 @@ version = rootProject.version
 configurations {
     create(Configurations.CORE_LIB).isTransitive = false
     create(Configurations.CORE_LIB_2).isTransitive = false
+    create(Configurations.CORE_LIB_CONFIG_2).isTransitive = false
 }
 
 dependencies {
@@ -41,6 +42,7 @@ dependencies {
     add(Configurations.GENERATED_CALLERS, project(":test:generated-callers:basic"))
     add(Configurations.CORE_LIB, libs.desugarJdkLibs)
     add(Configurations.CORE_LIB_2, libs.desugarJdkLibs2)
+    add(Configurations.CORE_LIB_CONFIG_2, libs.desugarJdkLibsConfig2)
 
     testImplementation(project(":test:d8-runner"))
     testImplementation(project(":test:base-api-tests"))

--- a/buildSrc/src/main/kotlin/signatures-core-lib-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/signatures-core-lib-conventions.gradle.kts
@@ -44,7 +44,10 @@ tasks.register<TypeDescriptorsTask>(CoreLibTasks.signaturesCoreLib) {
 tasks.register<TypeDescriptorsTask>(CoreLibTasks.signaturesCoreLib2) {
     classpath = configurations.getByName(Configurations.GENERATOR)
     sdk = configurations.getByName(Configurations.ANDROID_SDK)
-    desugar = configurations.getByName(Configurations.STANDARD_DESUGARED) + configurations.getByName(Configurations.CORE_LIB_2)
+    desugar = configurations.getByName(Configurations.STANDARD_DESUGARED)
+    desugaredCorelib.set(configurations.getByName(Configurations.CORE_LIB_2))
+    coreLibConfigJar.set(configurations.getByName(Configurations.CORE_LIB_CONFIG_2))
+    apiLevel.set(project.name.toInt())
     animalSnifferOutput = project.layout.buildDirectory.file(CoreLibOutputs.signaturesCoreLib2)
     expediterOutput = project.layout.buildDirectory.file(CoreLibOutputs.expediterCoreLib2)
     outputDescription = "Android API ${project.name} with Core Library Desugaring 2.x"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@ animalSniffer = "1.27"
 clikt = "5.1.0"
 expediter = "0.0.23"
 desugarJdkLibs = "1.2.3"
-desugarJdkLibs2 = "2.0.4"
+desugarJdkLibs2 = "2.1.5"
 r8 = "8.13.19"
 javapoet = "0.11.0"
 javassist = "3.30.2-GA"
@@ -21,6 +21,7 @@ animalSniffer = { module = "org.codehaus.mojo:animal-sniffer", version.ref = "an
 clikt = { module = "com.github.ajalt.clikt:clikt", version.ref = "clikt" }
 desugarJdkLibs = { module = "com.android.tools:desugar_jdk_libs", version.ref = "desugarJdkLibs" }
 desugarJdkLibs2 = { module = "com.android.tools:desugar_jdk_libs", version.ref = "desugarJdkLibs2" }
+desugarJdkLibsConfig2 = { module = "com.android.tools:desugar_jdk_libs_configuration", version.ref = "desugarJdkLibs2" }
 expediter-core = { module = "com.toasttab.expediter:core", version.ref = "expediter" }
 r8 = { module = "com.android.tools:r8", version.ref = "r8" }
 javapoet = { module = "com.palantir.javapoet:javapoet", version.ref = "javapoet" }

--- a/signature-builder/src/main/kotlin/com/toasttab/android/descriptors/AndroidTypeDescriptorBuilder.kt
+++ b/signature-builder/src/main/kotlin/com/toasttab/android/descriptors/AndroidTypeDescriptorBuilder.kt
@@ -33,12 +33,16 @@ import java.util.zip.GZIPOutputStream
 class AndroidTypeDescriptorBuilder : CliktCommand() {
     private val sdk: String by option(help = "SDK jar").required()
     private val desugared: List<String> by option(help = "desugared API jar(s)").multiple()
+    private val desugaredCorelib: List<String> by option("--desugared-corelib", help = "coreLib desugared API jar(s), filtered by lint file").multiple()
+    private val lintFile: String? by option("--lint-file", help = "desugared APIs lint file to filter coreLib classes")
 
     private val description: String by option(help = "description").required()
     private val animalSnifferOutput: String by option(help = "animal-sniffer-output").required()
     private val expediterOutput: String by option(help = "expediter-output").required()
 
     override fun run() {
+        val filter = lintFile?.let { LintFileFilter(File(it)) }
+
         val signatures =
             MutableTypeDescriptors(
                 ClasspathScanner(
@@ -48,7 +52,9 @@ class AndroidTypeDescriptorBuilder : CliktCommand() {
                 ).scan { stream, _ -> TypeParsers.typeDescriptor(stream) },
             )
 
-        for (more in desugared) {
+        for (more in desugared + desugaredCorelib) {
+            val applyFilter = filter != null && more in desugaredCorelib
+
             ClasspathScanner(
                 listOf(
                     ClassfileSource(File(more), ClassfileSourceType.UNKNOWN),
@@ -56,7 +62,11 @@ class AndroidTypeDescriptorBuilder : CliktCommand() {
             ).scan { stream, _ -> TransformedTypeDescriptor(TypeParsers.typeDescriptor(stream)) }
                 .sortedBy { it.priority }
                 .forEach {
-                    signatures.add(it.toType())
+                    val type = it.toType()
+                    val filtered = if (applyFilter) filter.filter(type) else type
+                    if (filtered != null) {
+                        signatures.add(filtered)
+                    }
                 }
         }
 

--- a/signature-builder/src/main/kotlin/com/toasttab/android/descriptors/LintFileFilter.kt
+++ b/signature-builder/src/main/kotlin/com/toasttab/android/descriptors/LintFileFilter.kt
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2026. Toast Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.toasttab.android.descriptors
+
+import protokt.v1.toasttab.expediter.v1.TypeDescriptor
+import java.io.File
+
+/**
+ * Filters [TypeDescriptor] entries based on a desugared APIs lint file from the
+ * `desugar_jdk_libs_configuration` artifact. The lint file lists exactly which APIs are made
+ * available through Android core library desugaring for a given minSdk/compileSdk combination.
+ *
+ * Classes not listed in the lint file (e.g. `CompletableFuture`, `ForkJoinPool`) are internal
+ * dependencies of the desugaring runtime and crash at runtime on older API levels — they must
+ * be excluded from the signature.
+ */
+class LintFileFilter(lintFile: File) {
+    /**
+     * Classes listed without any member qualifiers (e.g. `java/util/Optional`). The entire
+     * class is desugared, so all its methods and fields should be included.
+     */
+    private val classOnlyEntries: Set<String>
+
+    /**
+     * Classes that appear only with individual method entries (e.g. `java/lang/String#isBlank()Z`).
+     * The values are the set of allowed method signatures in JVM descriptor format
+     * (`name(params)returnType`). Only these methods should be included; all others must be
+     * stripped.
+     */
+    private val methodEntries: Map<String, Set<String>>
+
+    init {
+        val classOnly = mutableSetOf<String>()
+        val methods = mutableMapOf<String, MutableSet<String>>()
+        val classesWithMembers = mutableSetOf<String>()
+
+        for (line in lintFile.readLines()) {
+            val trimmed = line.trim()
+            if (trimmed.isEmpty()) continue
+
+            val hashIndex = trimmed.indexOf('#')
+            if (hashIndex < 0) {
+                classOnly.add(trimmed)
+            } else {
+                val className = trimmed.substring(0, hashIndex)
+                val memberSignature = trimmed.substring(hashIndex + 1)
+                classesWithMembers.add(className)
+
+                // Only track method signatures (contain parentheses).
+                // Field entries lack type descriptors, so all fields are preserved during filtering.
+                if (memberSignature.contains("(")) {
+                    methods.getOrPut(className) { mutableSetOf() }.add(memberSignature)
+                }
+            }
+        }
+
+        // Classes with member entries but no class-only entry need method-level filtering.
+        for (cls in classesWithMembers) {
+            if (cls !in classOnly) {
+                methods.getOrPut(cls) { mutableSetOf() }
+            }
+        }
+
+        // Class-only entries take precedence — no filtering needed for those.
+        classOnly.forEach { methods.remove(it) }
+
+        classOnlyEntries = classOnly
+        methodEntries = methods
+    }
+
+    /**
+     * Filters a [TypeDescriptor] based on the lint file entries. Returns `null` if the class
+     * should be excluded entirely.
+     *
+     * For class-only entries, the descriptor is returned unchanged. For method-entry classes,
+     * methods not listed in the lint file are stripped (constructors and fields are preserved).
+     */
+    fun filter(type: TypeDescriptor): TypeDescriptor? {
+        val topLevel = topLevelClass(type.name)
+
+        if (topLevel in classOnlyEntries) {
+            return type
+        }
+
+        val allowedMethods = methodEntries[topLevel] ?: return null
+
+        // Inner classes of method-entry classes are kept as-is.
+        if (type.name != topLevel) {
+            return type
+        }
+
+        val filteredMethods = type.methods.filter { method ->
+            val ref = method.ref
+            val sig = ref.name + ref.signature
+            sig in allowedMethods || ref.name == "<init>" || ref.name == "<clinit>"
+        }
+
+        return type.copy {
+            methods = filteredMethods
+        }
+    }
+
+    private fun topLevelClass(name: String): String {
+        val dollarIndex = name.indexOf('$')
+        return if (dollarIndex >= 0) name.substring(0, dollarIndex) else name
+    }
+}


### PR DESCRIPTION
Should fix https://github.com/open-toast/gummy-bears/issues/168

### Summary

Adds a lint-file-based filtering layer to coreLib2 signatures to exclude classes that are present in the `desugar_jdk_libs` JAR but are **not truly desugared** (i.e., they are internal runtime dependencies that crash on older API levels, like `CompletableFuture` on API 21, for example).

### Problem

The coreLib signatures are currently built by scanning **all** classes from the `desugar_jdk_libs` JAR. However, not every class in that JAR is a desugared public API. Some classes (like `CompletableFuture`, `ForkJoinPool`, and internal `sun/nio/fs/*` types) are implementation details of the desugaring runtime. Including them in the signature causes animalsniffer to silently accept references that will crash at runtime with `NoClassDefFoundError`.

### Solution

Google ships a `desugar_jdk_libs_configuration` artifact alongside `desugar_jdk_libs`. This artifact contains **lint files** (`desugared_apis_{compileSdk}_{minSdk}.txt`) that list exactly which APIs are made available through core library desugaring for a given minSdk.

This PR adds a filtering step that uses those lint files to strip non-desugared classes and methods from the coreLib2 signature:

- **Class-only entries** (e.g., `java/util/Optional`) → included as-is with all members
- **Method-level entries** (e.g., `java/lang/String#isBlank()Z`) → only the listed methods are kept; constructors and fields are preserved
- **Unlisted classes** (e.g., `java/util/concurrent/CompletableFuture`) → excluded entirely

The filter is applied **only to the coreLib JAR**, not to the standard API classes, and also **only to coreLib2** (desugaring 2.x) signatures. The coreLib (1.x) signatures remain unchanged.
