### PR TITLE
Fix spotless formatting in signature-builder

### DIFF
--- a/signature-builder/src/main/kotlin/com/toasttab/android/descriptors/AndroidTypeDescriptorBuilder.kt
+++ b/signature-builder/src/main/kotlin/com/toasttab/android/descriptors/AndroidTypeDescriptorBuilder.kt
@@ -33,7 +33,10 @@ import java.util.zip.GZIPOutputStream
 class AndroidTypeDescriptorBuilder : CliktCommand() {
     private val sdk: String by option(help = "SDK jar").required()
     private val desugared: List<String> by option(help = "desugared API jar(s)").multiple()
-    private val desugaredCorelib: List<String> by option("--desugared-corelib", help = "coreLib desugared API jar(s), filtered by lint file").multiple()
+    private val desugaredCorelib: List<String> by option(
+        "--desugared-corelib",
+        help = "coreLib desugared API jar(s), filtered by lint file",
+    ).multiple()
     private val lintFile: String? by option("--lint-file", help = "desugared APIs lint file to filter coreLib classes")
 
     private val description: String by option(help = "description").required()

--- a/signature-builder/src/main/kotlin/com/toasttab/android/descriptors/LintFileFilter.kt
+++ b/signature-builder/src/main/kotlin/com/toasttab/android/descriptors/LintFileFilter.kt
@@ -27,7 +27,9 @@ import java.io.File
  * dependencies of the desugaring runtime and crash at runtime on older API levels — they must
  * be excluded from the signature.
  */
-class LintFileFilter(lintFile: File) {
+class LintFileFilter(
+    lintFile: File,
+) {
     /**
      * Classes listed without any member qualifiers (e.g. `java/util/Optional`). The entire
      * class is desugared, so all its methods and fields should be included.
@@ -102,11 +104,12 @@ class LintFileFilter(lintFile: File) {
             return type
         }
 
-        val filteredMethods = type.methods.filter { method ->
-            val ref = method.ref
-            val sig = ref.name + ref.signature
-            sig in allowedMethods || ref.name == "<init>" || ref.name == "<clinit>"
-        }
+        val filteredMethods =
+            type.methods.filter { method ->
+                val ref = method.ref
+                val sig = ref.name + ref.signature
+                sig in allowedMethods || ref.name == "<init>" || ref.name == "<clinit>"
+            }
 
         return type.copy {
             methods = filteredMethods


### PR DESCRIPTION
## Summary
- Run `spotlessApply` to fix formatting in `AndroidTypeDescriptorBuilder.kt` and `LintFileFilter.kt`
- Formatting was out of sync after #172