### PR TITLE
Fix publishing to use new OSSRH staging API

### DIFF
--- a/buildSrc/src/main/kotlin/Common.kt
+++ b/buildSrc/src/main/kotlin/Common.kt
@@ -45,8 +45,6 @@ object Remote {
     val PASSWORD by lazy {
         System.getenv("OSSRH_PASSWORD")
     }
-
-    val url = "https://oss.sonatype.org/service/local/staging/deploy/maven2"
 }
 
 object Tasks {

--- a/buildSrc/src/main/kotlin/nexus-staging-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/nexus-staging-conventions.gradle.kts
@@ -6,6 +6,7 @@ if (isRelease()) {
     nexusPublishing {
         repositories {
             sonatype {
+                nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
                 username.set(Remote.USERNAME)
                 password.set(Remote.PASSWORD)
             }


### PR DESCRIPTION
## Summary
- Update `nexus-staging-conventions` to use the new OSSRH Central Portal staging API (`https://ossrh-staging-api.central.sonatype.com/service/local/`)
- Remove unused `Remote.url` constant pointing to the legacy `oss.sonatype.org` endpoint
