### PR TITLE
Remove core library desugaring v1 publishing

### DIFF
--- a/api/19/src/test/java/com/toasttab/android/Api19SignaturesTest.kt
+++ b/api/19/src/test/java/com/toasttab/android/Api19SignaturesTest.kt
@@ -38,10 +38,6 @@ class Api19SignaturesTest {
             signatures("signatures")
         }
 
-        private val coreLibSignatures by lazy {
-            signatures("coreLibSignatures")
-        }
-
         private val coreLibSignatures2 by lazy {
             signatures("coreLibSignatures2")
         }
@@ -75,15 +71,6 @@ class Api19SignaturesTest {
     }
 
     @Test
-    fun `core lib signatures include Stream#count()`() {
-        val stream = coreLibSignatures.find { it.name == "java/util/stream/Stream" }
-
-        expectThat(stream).isNotNull().and {
-            get { signatures }.contains("count()J")
-        }
-    }
-
-    @Test
     fun `core lib v2 signatures include Base64$Decoder#decode`() {
         val stream = coreLibSignatures2.find { it.name == "java/util/Base64\$Decoder" }
 
@@ -99,10 +86,4 @@ class Api19SignaturesTest {
         }
     }
 
-    @Test
-    fun `core lib signatures use HashSet`() {
-        expectThat(coreLibSignatures).all {
-            get { signatures }.isA<HashSet<*>>()
-        }
-    }
 }

--- a/api/19/src/test/java/com/toasttab/android/Api19SignaturesTest.kt
+++ b/api/19/src/test/java/com/toasttab/android/Api19SignaturesTest.kt
@@ -71,6 +71,15 @@ class Api19SignaturesTest {
     }
 
     @Test
+    fun `core lib v2 signatures include Stream#count()`() {
+        val stream = coreLibSignatures2.find { it.name == "java/util/stream/Stream" }
+
+        expectThat(stream).isNotNull().and {
+            get { signatures }.contains("count()J")
+        }
+    }
+
+    @Test
     fun `core lib v2 signatures include Base64$Decoder#decode`() {
         val stream = coreLibSignatures2.find { it.name == "java/util/Base64\$Decoder" }
 
@@ -86,4 +95,10 @@ class Api19SignaturesTest {
         }
     }
 
+    @Test
+    fun `core lib v2 signatures use HashSet`() {
+        expectThat(coreLibSignatures2).all {
+            get { signatures }.isA<HashSet<*>>()
+        }
+    }
 }

--- a/api/19/src/test/java/com/toasttab/android/Api19TypeDescriptorsTest.kt
+++ b/api/19/src/test/java/com/toasttab/android/Api19TypeDescriptorsTest.kt
@@ -66,6 +66,25 @@ class Api19TypeDescriptorsTest {
         }
     }
 
+    @Test
+    fun `core lib v2 type descriptors include Stream#count()`() {
+        val stream = coreLibDescriptors2.types.find { it.name == "java/util/stream/Stream" }
+
+        expectThat(stream).isNotNull().and {
+            get { methods }.contains(
+                MemberDescriptor {
+                    ref =
+                        SymbolicReference {
+                            name = "count"
+                            signature = "()J"
+                        }
+                    protection = AccessProtection.PUBLIC
+                    declaration = AccessDeclaration.INSTANCE
+                },
+            )
+        }
+    }
+
     /**
      * java.util.Base64 is included in desugar_jdk_libs starting with version 2.0.4
      */

--- a/api/19/src/test/java/com/toasttab/android/Api19TypeDescriptorsTest.kt
+++ b/api/19/src/test/java/com/toasttab/android/Api19TypeDescriptorsTest.kt
@@ -42,10 +42,6 @@ class Api19TypeDescriptorsTest {
             descriptors("platformDescriptors")
         }
 
-        private val coreLibDescriptors by lazy {
-            descriptors("platformCoreLibDescriptors")
-        }
-
         private val coreLibDescriptors2 by lazy {
             descriptors("platformCoreLibDescriptors2")
         }
@@ -65,25 +61,6 @@ class Api19TypeDescriptorsTest {
                         }
                     protection = AccessProtection.PUBLIC
                     declaration = AccessDeclaration.STATIC
-                },
-            )
-        }
-    }
-
-    @Test
-    fun `core lib type descriptors include Stream#count()`() {
-        val stream = coreLibDescriptors.types.find { it.name == "java/util/stream/Stream" }
-
-        expectThat(stream).isNotNull().and {
-            get { methods }.contains(
-                MemberDescriptor {
-                    ref =
-                        SymbolicReference {
-                            name = "count"
-                            signature = "()J"
-                        }
-                    protection = AccessProtection.PUBLIC
-                    declaration = AccessDeclaration.INSTANCE
                 },
             )
         }

--- a/buildSrc/src/main/kotlin/Common.kt
+++ b/buildSrc/src/main/kotlin/Common.kt
@@ -18,7 +18,6 @@ object Configurations {
     const val ANDROID_SDK = "_android_sdk_"
     const val STANDARD_DESUGARED = "_standard_desugared_signatures_"
     const val GENERATED_CALLERS = "_generated_callers_"
-    const val CORE_LIB = "_core_lib_"
     const val CORE_LIB_2 = "_core_lib_2_"
     const val CORE_LIB_CONFIG_2 = "_core_lib_config_2_"
 }

--- a/buildSrc/src/main/kotlin/signatures-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/signatures-conventions.gradle.kts
@@ -28,7 +28,6 @@ group = "com.toasttab.android"
 version = rootProject.version
 
 configurations {
-    create(Configurations.CORE_LIB).isTransitive = false
     create(Configurations.CORE_LIB_2).isTransitive = false
     create(Configurations.CORE_LIB_CONFIG_2).isTransitive = false
 }
@@ -40,7 +39,6 @@ dependencies {
         add(Configurations.STANDARD_DESUGARED, project(":desugared-signatures:unsafe24"))
     }
     add(Configurations.GENERATED_CALLERS, project(":test:generated-callers:basic"))
-    add(Configurations.CORE_LIB, libs.desugarJdkLibs)
     add(Configurations.CORE_LIB_2, libs.desugarJdkLibs2)
     add(Configurations.CORE_LIB_CONFIG_2, libs.desugarJdkLibsConfig2)
 

--- a/buildSrc/src/main/kotlin/signatures-core-lib-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/signatures-core-lib-conventions.gradle.kts
@@ -17,28 +17,16 @@ import org.gradle.api.publish.maven.MavenPublication
 import org.gradle.kotlin.dsl.register
 
 private object CoreLibTasks {
-    const val signaturesCoreLib = "buildSignaturesCoreLib"
     const val signaturesCoreLib2 = "buildSignaturesCoreLib2"
 }
 
 private object CoreLibOutputs {
-    const val signaturesCoreLib = "signaturesCoreLib.sig"
-    const val expediterCoreLib = "platformCoreLib.expediter"
     const val signaturesCoreLib2 = "signaturesCoreLib-2.sig"
     const val expediterCoreLib2 = "platformCoreLib-2.expediter"
 }
 
 plugins {
     id("signatures-conventions")
-}
-
-tasks.register<TypeDescriptorsTask>(CoreLibTasks.signaturesCoreLib) {
-    classpath = configurations.getByName(Configurations.GENERATOR)
-    sdk = configurations.getByName(Configurations.ANDROID_SDK)
-    desugar = configurations.getByName(Configurations.STANDARD_DESUGARED) + configurations.getByName(Configurations.CORE_LIB)
-    animalSnifferOutput = project.layout.buildDirectory.file(CoreLibOutputs.signaturesCoreLib)
-    expediterOutput = project.layout.buildDirectory.file(CoreLibOutputs.expediterCoreLib)
-    outputDescription = "Android API ${project.name} with Core Library Desugaring 1.x"
 }
 
 tasks.register<TypeDescriptorsTask>(CoreLibTasks.signaturesCoreLib2) {
@@ -55,18 +43,6 @@ tasks.register<TypeDescriptorsTask>(CoreLibTasks.signaturesCoreLib2) {
 
 
 publishing.publications.named<MavenPublication>(Publications.MAIN) {
-    artifact(layout.buildDirectory.file(CoreLibOutputs.signaturesCoreLib)) {
-        extension = "signature"
-        classifier = "coreLib"
-        builtBy(tasks.named(CoreLibTasks.signaturesCoreLib))
-    }
-
-    artifact(layout.buildDirectory.file(CoreLibOutputs.expediterCoreLib)) {
-        extension = "expediter"
-        classifier = "coreLib"
-        builtBy(tasks.named(CoreLibTasks.signaturesCoreLib))
-    }
-
     artifact(layout.buildDirectory.file(CoreLibOutputs.signaturesCoreLib2)) {
         extension = "signature"
         classifier = "coreLib2"
@@ -82,13 +58,9 @@ publishing.publications.named<MavenPublication>(Publications.MAIN) {
 
 tasks {
     test {
-        fileProperty("platformCoreLibDescriptors", layout.buildDirectory.file(CoreLibOutputs.expediterCoreLib))
-        fileProperty("coreLibSignatures", layout.buildDirectory.file(CoreLibOutputs.signaturesCoreLib))
-
         fileProperty("platformCoreLibDescriptors2", layout.buildDirectory.file(CoreLibOutputs.expediterCoreLib2))
         fileProperty("coreLibSignatures2", layout.buildDirectory.file(CoreLibOutputs.signaturesCoreLib2))
 
-        dependsOn(CoreLibTasks.signaturesCoreLib)
         dependsOn(CoreLibTasks.signaturesCoreLib2)
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,6 @@ kotlin = "2.3.20"
 animalSniffer = "1.27"
 clikt = "5.1.0"
 expediter = "0.0.23"
-desugarJdkLibs = "1.2.3"
 desugarJdkLibs2 = "2.1.5"
 r8 = "8.13.19"
 javapoet = "0.14.0"
@@ -19,7 +18,6 @@ androidxTest = "1.7.0"
 [libraries]
 animalSniffer = { module = "org.codehaus.mojo:animal-sniffer", version.ref = "animalSniffer" }
 clikt = { module = "com.github.ajalt.clikt:clikt", version.ref = "clikt" }
-desugarJdkLibs = { module = "com.android.tools:desugar_jdk_libs", version.ref = "desugarJdkLibs" }
 desugarJdkLibs2 = { module = "com.android.tools:desugar_jdk_libs", version.ref = "desugarJdkLibs2" }
 desugarJdkLibsConfig2 = { module = "com.android.tools:desugar_jdk_libs_configuration", version.ref = "desugarJdkLibs2" }
 expediter-core = { module = "com.toasttab.expediter:core", version.ref = "expediter" }


### PR DESCRIPTION
## Summary
- Remove coreLib v1 (`desugar_jdk_libs` 1.2.3) build task, published artifacts, configuration, dependency, and version catalog entry
- Only coreLib2 (`desugar_jdk_libs` 2.x) artifacts are published going forward
- Remove the coreLib v1 test in `Api19TypeDescriptorsTest`