### PR TITLE
Improve core library desugaring signature filtering

### DIFF
--- a/api/19/src/test/java/com/toasttab/android/Api19TypeDescriptorsTest.kt
+++ b/api/19/src/test/java/com/toasttab/android/Api19TypeDescriptorsTest.kt
@@ -171,6 +171,108 @@ class Api19TypeDescriptorsTest {
     }
 
     @Test
+    fun `core lib v2 type descriptors include remapped Duration#toSeconds()`() {
+        val duration = coreLibDescriptors2.types.find { it.name == "java/time/Duration" }
+
+        expectThat(duration).isNotNull().and {
+            get { methods }.contains(
+                MemberDescriptor {
+                    ref =
+                        SymbolicReference {
+                            name = "toSeconds"
+                            signature = "()J"
+                        }
+                    protection = AccessProtection.PUBLIC
+                    declaration = AccessDeclaration.INSTANCE
+                },
+            )
+        }
+    }
+
+    @Test
+    fun `core lib v2 type descriptors include remapped AtomicInteger#getAndUpdate()`() {
+        val atomicInt = coreLibDescriptors2.types.find { it.name == "java/util/concurrent/atomic/AtomicInteger" }
+
+        expectThat(atomicInt).isNotNull().and {
+            get { methods }.contains(
+                MemberDescriptor {
+                    ref =
+                        SymbolicReference {
+                            name = "getAndUpdate"
+                            signature = "(Ljava/util/function/IntUnaryOperator;)I"
+                        }
+                    protection = AccessProtection.PUBLIC
+                    declaration = AccessDeclaration.INSTANCE
+                },
+            )
+        }
+    }
+
+    @Test
+    fun `core lib v2 type descriptors include LocalDate#datesUntil()`() {
+        val localDate = coreLibDescriptors2.types.find { it.name == "java/time/LocalDate" }
+
+        expectThat(localDate).isNotNull().and {
+            get { methods }.contains(
+                MemberDescriptor {
+                    ref =
+                        SymbolicReference {
+                            name = "datesUntil"
+                            signature = "(Ljava/time/LocalDate;)Ljava/util/stream/Stream;"
+                        }
+                    protection = AccessProtection.PUBLIC
+                    declaration = AccessDeclaration.INSTANCE
+                },
+            )
+        }
+    }
+
+    @Test
+    fun `core lib v2 type descriptors include ConcurrentHashMap`() {
+        val chm = coreLibDescriptors2.types.find { it.name == "java/util/concurrent/ConcurrentHashMap" }
+
+        expectThat(chm).isNotNull()
+    }
+
+    @Test
+    fun `core lib v2 type descriptors include AtomicReference#compareAndSet()`() {
+        val atomicRef = coreLibDescriptors2.types.find { it.name == "java/util/concurrent/atomic/AtomicReference" }
+
+        expectThat(atomicRef).isNotNull().and {
+            get { methods }.contains(
+                MemberDescriptor {
+                    ref =
+                        SymbolicReference {
+                            name = "compareAndSet"
+                            signature = "(Ljava/lang/Object;Ljava/lang/Object;)Z"
+                        }
+                    protection = AccessProtection.PUBLIC
+                    declaration = AccessDeclaration.INSTANCE
+                },
+            )
+        }
+    }
+
+    @Test
+    fun `core lib v2 type descriptors include Instant`() {
+        val instant = coreLibDescriptors2.types.find { it.name == "java/time/Instant" }
+
+        expectThat(instant).isNotNull().and {
+            get { methods }.contains(
+                MemberDescriptor {
+                    ref =
+                        SymbolicReference {
+                            name = "now"
+                            signature = "()Ljava/time/Instant;"
+                        }
+                    protection = AccessProtection.PUBLIC
+                    declaration = AccessDeclaration.STATIC
+                },
+            )
+        }
+    }
+
+    @Test
     fun `descriptors include Unsafe#getInt`() {
         val integer = descriptors.types.find { it.name == "sun/misc/Unsafe" }
 

--- a/signature-builder/src/main/kotlin/com/toasttab/android/descriptors/AndroidTypeDescriptorBuilder.kt
+++ b/signature-builder/src/main/kotlin/com/toasttab/android/descriptors/AndroidTypeDescriptorBuilder.kt
@@ -44,7 +44,7 @@ class AndroidTypeDescriptorBuilder : CliktCommand() {
     private val expediterOutput: String by option(help = "expediter-output").required()
 
     override fun run() {
-        val filter = lintFile?.let { LintFileFilter(File(it)) }
+        val coreLibFilter = CoreLibFilter(lintFile?.let { File(it) })
 
         val signatures =
             MutableTypeDescriptors(
@@ -55,9 +55,7 @@ class AndroidTypeDescriptorBuilder : CliktCommand() {
                 ).scan { stream, _ -> TypeParsers.typeDescriptor(stream) },
             )
 
-        for (more in desugared + desugaredCorelib) {
-            val applyFilter = filter != null && more in desugaredCorelib
-
+        for (more in desugared) {
             ClasspathScanner(
                 listOf(
                     ClassfileSource(File(more), ClassfileSourceType.UNKNOWN),
@@ -65,11 +63,19 @@ class AndroidTypeDescriptorBuilder : CliktCommand() {
             ).scan { stream, _ -> TransformedTypeDescriptor(TypeParsers.typeDescriptor(stream)) }
                 .sortedBy { it.priority }
                 .forEach {
-                    val type = it.toType()
-                    val filtered = if (applyFilter) filter.filter(type) else type
-                    if (filtered != null) {
-                        signatures.add(filtered)
-                    }
+                    signatures.add(it.toType())
+                }
+        }
+
+        for (more in desugaredCorelib) {
+            ClasspathScanner(
+                listOf(
+                    ClassfileSource(File(more), ClassfileSourceType.UNKNOWN),
+                ),
+            ).scan { stream, _ -> TransformedTypeDescriptor(TypeParsers.typeDescriptor(stream)) }
+                .sortedBy { it.priority }
+                .forEach {
+                    coreLibFilter.filter(it.toType())?.let(signatures::add)
                 }
         }
 

--- a/signature-builder/src/main/kotlin/com/toasttab/android/descriptors/CoreLibFilter.kt
+++ b/signature-builder/src/main/kotlin/com/toasttab/android/descriptors/CoreLibFilter.kt
@@ -29,18 +29,21 @@ import java.io.File
  *
  * Returns `null` if the type should be excluded entirely.
  */
-class CoreLibFilter(lintFile: File?) {
+class CoreLibFilter(
+    lintFile: File?,
+) {
     private val lintFileFilter = lintFile?.let { LintFileFilter(it) }
 
     /**
      * Methods present in the core library desugaring jar that do not exist
      * on JVM 17 and must be excluded from the signature.
      */
-    private val excludedMethods: Map<String, Set<String>> = mapOf(
-        "java/util/concurrent/ThreadLocalRandom" to setOf("nextGaussian()D"),
-        "java/time/chrono/IsoChronology" to setOf("<init>()V"),
-        "java/time/Duration" to setOf("<init>()V"),
-    )
+    private val excludedMethods: Map<String, Set<String>> =
+        mapOf(
+            "java/util/concurrent/ThreadLocalRandom" to setOf("nextGaussian()D"),
+            "java/time/chrono/IsoChronology" to setOf("<init>()V"),
+            "java/time/Duration" to setOf("<init>()V"),
+        )
 
     fun filter(type: TypeDescriptor): TypeDescriptor? {
         if (!type.name.startsWith("java/") && !type.name.startsWith("javax/")) {
@@ -51,28 +54,30 @@ class CoreLibFilter(lintFile: File?) {
             return null
         }
 
-        val publicMembers = type.copy {
-            methods = type.methods.filter { it.protection.isPublicOrProtected() }
-            fields = type.fields.filter { it.protection.isPublicOrProtected() }
-        }
+        val publicMembers =
+            type.copy {
+                methods = type.methods.filter { it.protection.isPublicOrProtected() }
+                fields = type.fields.filter { it.protection.isPublicOrProtected() }
+            }
 
         val remapped = CoreLibMethodRemapper.remap(publicMembers)
 
         val excluded = excludedMethods[remapped.name]
-        val cleaned = if (excluded != null) {
-            remapped.copy {
-                methods = remapped.methods.filter { m ->
-                    val ref = m.requireRef
-                    ref.name + ref.signature !in excluded
+        val cleaned =
+            if (excluded != null) {
+                remapped.copy {
+                    methods =
+                        remapped.methods.filter { m ->
+                            val ref = m.requireRef
+                            ref.name + ref.signature !in excluded
+                        }
                 }
+            } else {
+                remapped
             }
-        } else {
-            remapped
-        }
 
         return if (lintFileFilter != null) lintFileFilter.filter(cleaned) else cleaned
     }
 }
 
-private fun AccessProtection.isPublicOrProtected() =
-    this == AccessProtection.PUBLIC || this == AccessProtection.PROTECTED
+private fun AccessProtection.isPublicOrProtected() = this == AccessProtection.PUBLIC || this == AccessProtection.PROTECTED

--- a/signature-builder/src/main/kotlin/com/toasttab/android/descriptors/CoreLibFilter.kt
+++ b/signature-builder/src/main/kotlin/com/toasttab/android/descriptors/CoreLibFilter.kt
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2026. Toast Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.toasttab.android.descriptors
+
+import protokt.v1.toasttab.expediter.v1.AccessProtection
+import protokt.v1.toasttab.expediter.v1.TypeDescriptor
+import java.io.File
+
+/**
+ * Filters and transforms core library desugaring types. Applies the following steps in order:
+ *
+ * 1. Excludes classes outside `java/` and `javax/` packages.
+ * 2. Excludes non-public/protected classes and strips non-public/protected members.
+ * 3. Remaps static companion methods back to instance methods.
+ * 4. Applies lint file filtering (if a lint file was provided).
+ *
+ * Returns `null` if the type should be excluded entirely.
+ */
+class CoreLibFilter(lintFile: File?) {
+    private val lintFileFilter = lintFile?.let { LintFileFilter(it) }
+
+    /**
+     * Methods present in the core library desugaring jar that do not exist
+     * on JVM 17 and must be excluded from the signature.
+     */
+    private val excludedMethods: Map<String, Set<String>> = mapOf(
+        "java/util/concurrent/ThreadLocalRandom" to setOf("nextGaussian()D"),
+        "java/time/chrono/IsoChronology" to setOf("<init>()V"),
+        "java/time/Duration" to setOf("<init>()V"),
+    )
+
+    fun filter(type: TypeDescriptor): TypeDescriptor? {
+        if (!type.name.startsWith("java/") && !type.name.startsWith("javax/")) {
+            return null
+        }
+
+        if (!type.protection.isPublicOrProtected()) {
+            return null
+        }
+
+        val publicMembers = type.copy {
+            methods = type.methods.filter { it.protection.isPublicOrProtected() }
+            fields = type.fields.filter { it.protection.isPublicOrProtected() }
+        }
+
+        val remapped = CoreLibMethodRemapper.remap(publicMembers)
+
+        val excluded = excludedMethods[remapped.name]
+        val cleaned = if (excluded != null) {
+            remapped.copy {
+                methods = remapped.methods.filter { m ->
+                    val ref = m.requireRef
+                    ref.name + ref.signature !in excluded
+                }
+            }
+        } else {
+            remapped
+        }
+
+        return if (lintFileFilter != null) lintFileFilter.filter(cleaned) else cleaned
+    }
+}
+
+private fun AccessProtection.isPublicOrProtected() =
+    this == AccessProtection.PUBLIC || this == AccessProtection.PROTECTED

--- a/signature-builder/src/main/kotlin/com/toasttab/android/descriptors/CoreLibMethodRemapper.kt
+++ b/signature-builder/src/main/kotlin/com/toasttab/android/descriptors/CoreLibMethodRemapper.kt
@@ -33,97 +33,117 @@ object CoreLibMethodRemapper {
      * Map from class name to the set of static method signatures that need to be remapped.
      * Each entry is in the format `methodName(staticDescriptor)returnType`.
      */
-    private val remappedMethods: Map<String, Set<String>> = mapOf(
-        "java/io/BufferedReader" to setOf(
-            "lines(Ljava/io/BufferedReader;)Ljava/util/stream/Stream;",
-        ),
-        "java/io/File" to setOf(
-            "toPath(Ljava/io/File;)Ljava/nio/file/Path;",
-        ),
-        "java/io/InputStream" to setOf(
-            "transferTo(Ljava/io/InputStream;Ljava/io/OutputStream;)J",
-        ),
-        "java/time/LocalTime" to setOf(
-            "toEpochSecond(Ljava/time/LocalTime;Ljava/time/LocalDate;Ljava/time/ZoneOffset;)J",
-        ),
-        "java/time/chrono/IsoChronology" to setOf(
-            "epochSecond(Ljava/time/chrono/IsoChronology;IIIIIILjava/time/ZoneOffset;)J",
-        ),
-        "java/time/LocalDate" to setOf(
-            "datesUntil(Ljava/time/LocalDate;Ljava/time/LocalDate;)Ljava/util/stream/Stream;",
-            "datesUntil(Ljava/time/LocalDate;Ljava/time/LocalDate;Ljava/time/Period;)Ljava/util/stream/Stream;",
-            "toEpochSecond(Ljava/time/LocalDate;Ljava/time/LocalTime;Ljava/time/ZoneOffset;)J",
-        ),
-        "java/time/Duration" to setOf(
-            "dividedBy(Ljava/time/Duration;Ljava/time/Duration;)J",
-            "toSeconds(Ljava/time/Duration;)J",
-            "toDaysPart(Ljava/time/Duration;)J",
-            "toHoursPart(Ljava/time/Duration;)I",
-            "toMinutesPart(Ljava/time/Duration;)I",
-            "toSecondsPart(Ljava/time/Duration;)I",
-            "toMillisPart(Ljava/time/Duration;)I",
-            "toNanosPart(Ljava/time/Duration;)I",
-            "truncatedTo(Ljava/time/Duration;Ljava/time/temporal/TemporalUnit;)Ljava/time/Duration;",
-        ),
-        "java/time/OffsetTime" to setOf(
-            "toEpochSecond(Ljava/time/OffsetTime;Ljava/time/LocalDate;)J",
-        ),
-        "java/util/TimeZone" to setOf(
-            "toZoneId(Ljava/util/TimeZone;)Ljava/time/ZoneId;",
-        ),
-        "java/util/LinkedHashSet" to setOf(
-            "spliterator(Ljava/util/LinkedHashSet;)Ljava/util/Spliterator;",
-        ),
-        "java/util/Date" to setOf(
-            "toInstant(Ljava/util/Date;)Ljava/time/Instant;",
-        ),
-        "java/util/GregorianCalendar" to setOf(
-            "toZonedDateTime(Ljava/util/GregorianCalendar;)Ljava/time/ZonedDateTime;",
-        ),
-        "java/util/Calendar" to setOf(
-            "toInstant(Ljava/util/Calendar;)Ljava/time/Instant;",
-        ),
-        "java/util/concurrent/atomic/AtomicLong" to setOf(
-            "getAndUpdate(Ljava/util/concurrent/atomic/AtomicLong;Ljava/util/function/LongUnaryOperator;)J",
-            "updateAndGet(Ljava/util/concurrent/atomic/AtomicLong;Ljava/util/function/LongUnaryOperator;)J",
-            "getAndAccumulate(Ljava/util/concurrent/atomic/AtomicLong;JLjava/util/function/LongBinaryOperator;)J",
-            "accumulateAndGet(Ljava/util/concurrent/atomic/AtomicLong;JLjava/util/function/LongBinaryOperator;)J",
-        ),
-        "java/util/concurrent/atomic/AtomicInteger" to setOf(
-            "getAndUpdate(Ljava/util/concurrent/atomic/AtomicInteger;Ljava/util/function/IntUnaryOperator;)I",
-            "updateAndGet(Ljava/util/concurrent/atomic/AtomicInteger;Ljava/util/function/IntUnaryOperator;)I",
-            "getAndAccumulate(Ljava/util/concurrent/atomic/AtomicInteger;ILjava/util/function/IntBinaryOperator;)I",
-            "accumulateAndGet(Ljava/util/concurrent/atomic/AtomicInteger;ILjava/util/function/IntBinaryOperator;)I",
-        ),
-        "java/util/concurrent/atomic/AtomicReference" to setOf(
-            "getAndUpdate(Ljava/util/concurrent/atomic/AtomicReference;Ljava/util/function/UnaryOperator;)Ljava/lang/Object;",
-            "updateAndGet(Ljava/util/concurrent/atomic/AtomicReference;Ljava/util/function/UnaryOperator;)Ljava/lang/Object;",
-            "getAndAccumulate(Ljava/util/concurrent/atomic/AtomicReference;Ljava/lang/Object;Ljava/util/function/BinaryOperator;)Ljava/lang/Object;",
-            "accumulateAndGet(Ljava/util/concurrent/atomic/AtomicReference;Ljava/lang/Object;Ljava/util/function/BinaryOperator;)Ljava/lang/Object;",
-        ),
-        "java/util/concurrent/TimeUnit" to setOf(
-            "toChronoUnit(Ljava/util/concurrent/TimeUnit;)Ljava/time/temporal/ChronoUnit;",
-            "convert(Ljava/util/concurrent/TimeUnit;Ljava/time/Duration;)J",
-        ),
-    )
+    private val remappedMethods: Map<String, Set<String>> =
+        mapOf(
+            "java/io/BufferedReader" to
+                setOf(
+                    "lines(Ljava/io/BufferedReader;)Ljava/util/stream/Stream;",
+                ),
+            "java/io/File" to
+                setOf(
+                    "toPath(Ljava/io/File;)Ljava/nio/file/Path;",
+                ),
+            "java/io/InputStream" to
+                setOf(
+                    "transferTo(Ljava/io/InputStream;Ljava/io/OutputStream;)J",
+                ),
+            "java/time/LocalTime" to
+                setOf(
+                    "toEpochSecond(Ljava/time/LocalTime;Ljava/time/LocalDate;Ljava/time/ZoneOffset;)J",
+                ),
+            "java/time/chrono/IsoChronology" to
+                setOf(
+                    "epochSecond(Ljava/time/chrono/IsoChronology;IIIIIILjava/time/ZoneOffset;)J",
+                ),
+            "java/time/LocalDate" to
+                setOf(
+                    "datesUntil(Ljava/time/LocalDate;Ljava/time/LocalDate;)Ljava/util/stream/Stream;",
+                    "datesUntil(Ljava/time/LocalDate;Ljava/time/LocalDate;Ljava/time/Period;)Ljava/util/stream/Stream;",
+                    "toEpochSecond(Ljava/time/LocalDate;Ljava/time/LocalTime;Ljava/time/ZoneOffset;)J",
+                ),
+            "java/time/Duration" to
+                setOf(
+                    "dividedBy(Ljava/time/Duration;Ljava/time/Duration;)J",
+                    "toSeconds(Ljava/time/Duration;)J",
+                    "toDaysPart(Ljava/time/Duration;)J",
+                    "toHoursPart(Ljava/time/Duration;)I",
+                    "toMinutesPart(Ljava/time/Duration;)I",
+                    "toSecondsPart(Ljava/time/Duration;)I",
+                    "toMillisPart(Ljava/time/Duration;)I",
+                    "toNanosPart(Ljava/time/Duration;)I",
+                    "truncatedTo(Ljava/time/Duration;Ljava/time/temporal/TemporalUnit;)Ljava/time/Duration;",
+                ),
+            "java/time/OffsetTime" to
+                setOf(
+                    "toEpochSecond(Ljava/time/OffsetTime;Ljava/time/LocalDate;)J",
+                ),
+            "java/util/TimeZone" to
+                setOf(
+                    "toZoneId(Ljava/util/TimeZone;)Ljava/time/ZoneId;",
+                ),
+            "java/util/LinkedHashSet" to
+                setOf(
+                    "spliterator(Ljava/util/LinkedHashSet;)Ljava/util/Spliterator;",
+                ),
+            "java/util/Date" to
+                setOf(
+                    "toInstant(Ljava/util/Date;)Ljava/time/Instant;",
+                ),
+            "java/util/GregorianCalendar" to
+                setOf(
+                    "toZonedDateTime(Ljava/util/GregorianCalendar;)Ljava/time/ZonedDateTime;",
+                ),
+            "java/util/Calendar" to
+                setOf(
+                    "toInstant(Ljava/util/Calendar;)Ljava/time/Instant;",
+                ),
+            "java/util/concurrent/atomic/AtomicLong" to
+                setOf(
+                    "getAndUpdate(Ljava/util/concurrent/atomic/AtomicLong;Ljava/util/function/LongUnaryOperator;)J",
+                    "updateAndGet(Ljava/util/concurrent/atomic/AtomicLong;Ljava/util/function/LongUnaryOperator;)J",
+                    "getAndAccumulate(Ljava/util/concurrent/atomic/AtomicLong;JLjava/util/function/LongBinaryOperator;)J",
+                    "accumulateAndGet(Ljava/util/concurrent/atomic/AtomicLong;JLjava/util/function/LongBinaryOperator;)J",
+                ),
+            "java/util/concurrent/atomic/AtomicInteger" to
+                setOf(
+                    "getAndUpdate(Ljava/util/concurrent/atomic/AtomicInteger;Ljava/util/function/IntUnaryOperator;)I",
+                    "updateAndGet(Ljava/util/concurrent/atomic/AtomicInteger;Ljava/util/function/IntUnaryOperator;)I",
+                    "getAndAccumulate(Ljava/util/concurrent/atomic/AtomicInteger;ILjava/util/function/IntBinaryOperator;)I",
+                    "accumulateAndGet(Ljava/util/concurrent/atomic/AtomicInteger;ILjava/util/function/IntBinaryOperator;)I",
+                ),
+            "java/util/concurrent/atomic/AtomicReference" to
+                setOf(
+                    "getAndUpdate(Ljava/util/concurrent/atomic/AtomicReference;Ljava/util/function/UnaryOperator;)Ljava/lang/Object;",
+                    "updateAndGet(Ljava/util/concurrent/atomic/AtomicReference;Ljava/util/function/UnaryOperator;)Ljava/lang/Object;",
+                    "getAndAccumulate(Ljava/util/concurrent/atomic/AtomicReference;Ljava/lang/Object;Ljava/util/function/BinaryOperator;)Ljava/lang/Object;",
+                    "accumulateAndGet(Ljava/util/concurrent/atomic/AtomicReference;Ljava/lang/Object;Ljava/util/function/BinaryOperator;)Ljava/lang/Object;",
+                ),
+            "java/util/concurrent/TimeUnit" to
+                setOf(
+                    "toChronoUnit(Ljava/util/concurrent/TimeUnit;)Ljava/time/temporal/ChronoUnit;",
+                    "convert(Ljava/util/concurrent/TimeUnit;Ljava/time/Duration;)J",
+                ),
+        )
 
     fun remap(type: TypeDescriptor): TypeDescriptor {
         val entries = remappedMethods[type.name] ?: return type
-        val methods = type.methods.map { method ->
-            val ref = method.requireRef
-            val key = ref.name + ref.signature
-            if (method.declaration == AccessDeclaration.STATIC && key in entries) {
-                method.copy {
-                    this.ref = SymbolicReference {
-                        name = ref.name
-                        signature = stripFirstParameter(ref.signature)
+        val methods =
+            type.methods.map { method ->
+                val ref = method.requireRef
+                val key = ref.name + ref.signature
+                if (method.declaration == AccessDeclaration.STATIC && key in entries) {
+                    method.copy {
+                        this.ref =
+                            SymbolicReference {
+                                name = ref.name
+                                signature = stripFirstParameter(ref.signature)
+                            }
+                        declaration = AccessDeclaration.INSTANCE
                     }
-                    declaration = AccessDeclaration.INSTANCE
+                } else {
+                    method
                 }
-            } else {
-                method
             }
-        }
         return type.copy { this.methods = methods }
     }
 

--- a/signature-builder/src/main/kotlin/com/toasttab/android/descriptors/CoreLibMethodRemapper.kt
+++ b/signature-builder/src/main/kotlin/com/toasttab/android/descriptors/CoreLibMethodRemapper.kt
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2026. Toast Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.toasttab.android.descriptors
+
+import com.toasttab.expediter.parser.MethodSignature
+import com.toasttab.expediter.parser.SignatureParser
+import protokt.v1.toasttab.expediter.v1.AccessDeclaration
+import protokt.v1.toasttab.expediter.v1.SymbolicReference
+import protokt.v1.toasttab.expediter.v1.TypeDescriptor
+
+/**
+ * Remaps static methods in core library desugaring back to their original instance method
+ * signatures. During desugaring, some instance methods are transformed into static methods
+ * where the receiver type is prepended as the first parameter (e.g.
+ * `BufferedReader.lines()` becomes `static lines(BufferedReader)`). This class reverses
+ * that transformation.
+ */
+object CoreLibMethodRemapper {
+    /**
+     * Map from class name to the set of static method signatures that need to be remapped.
+     * Each entry is in the format `methodName(staticDescriptor)returnType`.
+     */
+    private val remappedMethods: Map<String, Set<String>> = mapOf(
+        "java/io/BufferedReader" to setOf(
+            "lines(Ljava/io/BufferedReader;)Ljava/util/stream/Stream;",
+        ),
+        "java/io/File" to setOf(
+            "toPath(Ljava/io/File;)Ljava/nio/file/Path;",
+        ),
+        "java/io/InputStream" to setOf(
+            "transferTo(Ljava/io/InputStream;Ljava/io/OutputStream;)J",
+        ),
+        "java/time/LocalTime" to setOf(
+            "toEpochSecond(Ljava/time/LocalTime;Ljava/time/LocalDate;Ljava/time/ZoneOffset;)J",
+        ),
+        "java/time/chrono/IsoChronology" to setOf(
+            "epochSecond(Ljava/time/chrono/IsoChronology;IIIIIILjava/time/ZoneOffset;)J",
+        ),
+        "java/time/LocalDate" to setOf(
+            "datesUntil(Ljava/time/LocalDate;Ljava/time/LocalDate;)Ljava/util/stream/Stream;",
+            "datesUntil(Ljava/time/LocalDate;Ljava/time/LocalDate;Ljava/time/Period;)Ljava/util/stream/Stream;",
+            "toEpochSecond(Ljava/time/LocalDate;Ljava/time/LocalTime;Ljava/time/ZoneOffset;)J",
+        ),
+        "java/time/Duration" to setOf(
+            "dividedBy(Ljava/time/Duration;Ljava/time/Duration;)J",
+            "toSeconds(Ljava/time/Duration;)J",
+            "toDaysPart(Ljava/time/Duration;)J",
+            "toHoursPart(Ljava/time/Duration;)I",
+            "toMinutesPart(Ljava/time/Duration;)I",
+            "toSecondsPart(Ljava/time/Duration;)I",
+            "toMillisPart(Ljava/time/Duration;)I",
+            "toNanosPart(Ljava/time/Duration;)I",
+            "truncatedTo(Ljava/time/Duration;Ljava/time/temporal/TemporalUnit;)Ljava/time/Duration;",
+        ),
+        "java/time/OffsetTime" to setOf(
+            "toEpochSecond(Ljava/time/OffsetTime;Ljava/time/LocalDate;)J",
+        ),
+        "java/util/TimeZone" to setOf(
+            "toZoneId(Ljava/util/TimeZone;)Ljava/time/ZoneId;",
+        ),
+        "java/util/LinkedHashSet" to setOf(
+            "spliterator(Ljava/util/LinkedHashSet;)Ljava/util/Spliterator;",
+        ),
+        "java/util/Date" to setOf(
+            "toInstant(Ljava/util/Date;)Ljava/time/Instant;",
+        ),
+        "java/util/GregorianCalendar" to setOf(
+            "toZonedDateTime(Ljava/util/GregorianCalendar;)Ljava/time/ZonedDateTime;",
+        ),
+        "java/util/Calendar" to setOf(
+            "toInstant(Ljava/util/Calendar;)Ljava/time/Instant;",
+        ),
+        "java/util/concurrent/atomic/AtomicLong" to setOf(
+            "getAndUpdate(Ljava/util/concurrent/atomic/AtomicLong;Ljava/util/function/LongUnaryOperator;)J",
+            "updateAndGet(Ljava/util/concurrent/atomic/AtomicLong;Ljava/util/function/LongUnaryOperator;)J",
+            "getAndAccumulate(Ljava/util/concurrent/atomic/AtomicLong;JLjava/util/function/LongBinaryOperator;)J",
+            "accumulateAndGet(Ljava/util/concurrent/atomic/AtomicLong;JLjava/util/function/LongBinaryOperator;)J",
+        ),
+        "java/util/concurrent/atomic/AtomicInteger" to setOf(
+            "getAndUpdate(Ljava/util/concurrent/atomic/AtomicInteger;Ljava/util/function/IntUnaryOperator;)I",
+            "updateAndGet(Ljava/util/concurrent/atomic/AtomicInteger;Ljava/util/function/IntUnaryOperator;)I",
+            "getAndAccumulate(Ljava/util/concurrent/atomic/AtomicInteger;ILjava/util/function/IntBinaryOperator;)I",
+            "accumulateAndGet(Ljava/util/concurrent/atomic/AtomicInteger;ILjava/util/function/IntBinaryOperator;)I",
+        ),
+        "java/util/concurrent/atomic/AtomicReference" to setOf(
+            "getAndUpdate(Ljava/util/concurrent/atomic/AtomicReference;Ljava/util/function/UnaryOperator;)Ljava/lang/Object;",
+            "updateAndGet(Ljava/util/concurrent/atomic/AtomicReference;Ljava/util/function/UnaryOperator;)Ljava/lang/Object;",
+            "getAndAccumulate(Ljava/util/concurrent/atomic/AtomicReference;Ljava/lang/Object;Ljava/util/function/BinaryOperator;)Ljava/lang/Object;",
+            "accumulateAndGet(Ljava/util/concurrent/atomic/AtomicReference;Ljava/lang/Object;Ljava/util/function/BinaryOperator;)Ljava/lang/Object;",
+        ),
+        "java/util/concurrent/TimeUnit" to setOf(
+            "toChronoUnit(Ljava/util/concurrent/TimeUnit;)Ljava/time/temporal/ChronoUnit;",
+            "convert(Ljava/util/concurrent/TimeUnit;Ljava/time/Duration;)J",
+        ),
+    )
+
+    fun remap(type: TypeDescriptor): TypeDescriptor {
+        val entries = remappedMethods[type.name] ?: return type
+        val methods = type.methods.map { method ->
+            val ref = method.requireRef
+            val key = ref.name + ref.signature
+            if (method.declaration == AccessDeclaration.STATIC && key in entries) {
+                method.copy {
+                    this.ref = SymbolicReference {
+                        name = ref.name
+                        signature = stripFirstParameter(ref.signature)
+                    }
+                    declaration = AccessDeclaration.INSTANCE
+                }
+            } else {
+                method
+            }
+        }
+        return type.copy { this.methods = methods }
+    }
+
+    private fun stripFirstParameter(signature: String): String {
+        val parsed = SignatureParser.parseMethod(signature)
+        return MethodSignature(parsed.returnType, parsed.argumentTypes.drop(1)).toDescriptor()
+    }
+}


### PR DESCRIPTION
## Summary
- Filter core library desugaring signatures to only include `java/`/`javax/` classes with public/protected visibility
- Remap static companion methods back to their original instance method signatures (e.g. `static Duration.toSeconds(Duration)` → `Duration.toSeconds()`) using a mapping extracted from the desugaring configuration
- Exclude extraneous methods not present in JVM 17 (e.g. `Duration.<init>()`, `ThreadLocalRandom.nextGaussian()`)
- Extract all corelib-specific filtering into `CoreLibFilter` and `CoreLibMethodRemapper`

## Test plan
- [x] New tests for remapped methods (`Duration#toSeconds`, `AtomicInteger#getAndUpdate`, `LocalDate#datesUntil`)
- [x] New tests for `java.util.concurrent` APIs (`ConcurrentHashMap`, `AtomicReference#compareAndSet`)
- [x] New tests for `java.time` APIs (`Instant#now`)
- [x] Existing tests pass

Fixes https://github.com/open-toast/gummy-bears/issues/109