### PR TITLE
Read lint file directly from JAR via jar: URL

### DIFF
--- a/buildSrc/src/main/kotlin/LintFileSelector.kt
+++ b/buildSrc/src/main/kotlin/LintFileSelector.kt
@@ -14,35 +14,31 @@
  */
 
 import java.io.File
+import java.net.URI
 import java.util.zip.ZipFile
 
 object LintFileSelector {
     private val LINT_FILE_PATTERN = Regex("""desugared_apis_(\d+)_(\d+)\.txt""")
 
-    /**
-     * Represents a parsed lint file with its compileSdk and minSdk thresholds.
-     */
     private data class LintFileCandidate(
-        val file: File,
+        val entryName: String,
         val compileSdk: Int,
         val minSdk: Int,
     )
 
     /**
-     * Extracts lint files from a `desugar_jdk_libs_configuration` JAR and selects the best one
-     * for the given API level. Mirrors Android Gradle Plugin's selection logic:
+     * Selects the best lint file from a `desugar_jdk_libs_configuration` JAR for the given API
+     * level. Mirrors Android Gradle Plugin's selection logic:
      * 1. Pick the highest compileSdk directory available.
      * 2. Within that, pick the lint file with the highest minSdk threshold that does not exceed
      *    the target API level.
      *
      * @param configJar the `desugar_jdk_libs_configuration` JAR file
      * @param apiLevel the target Android API level (minSdk)
-     * @param outputDir directory to extract lint files into
-     * @return the selected lint file, or null if no matching lint file was found
+     * @return a `jar:` URI pointing to the selected lint file inside the JAR, or null if no
+     *         matching lint file was found
      */
-    fun selectLintFile(configJar: File, apiLevel: Int, outputDir: File): File? {
-        outputDir.mkdirs()
-
+    fun selectLintFile(configJar: File, apiLevel: Int): URI? {
         val candidates = mutableListOf<LintFileCandidate>()
 
         ZipFile(configJar).use { zip ->
@@ -53,15 +49,7 @@ object LintFileSelector {
                 val compileSdk = match.groupValues[1].toInt()
                 val minSdk = match.groupValues[2].toInt()
 
-                val outFile = File(outputDir, entry.name)
-                outFile.parentFile.mkdirs()
-                zip.getInputStream(entry).use { input ->
-                    outFile.outputStream().use { output ->
-                        input.copyTo(output)
-                    }
-                }
-
-                candidates.add(LintFileCandidate(outFile, compileSdk, minSdk))
+                candidates.add(LintFileCandidate(entry.name, compileSdk, minSdk))
             }
         }
 
@@ -69,9 +57,11 @@ object LintFileSelector {
 
         val highestCompileSdk = candidates.maxOf { it.compileSdk }
 
-        return candidates
+        val selected = candidates
             .filter { it.compileSdk == highestCompileSdk && it.minSdk <= apiLevel }
             .maxByOrNull { it.minSdk }
-            ?.file
+            ?: return null
+
+        return URI("jar:${configJar.toURI()}!/${selected.entryName}")
     }
 }

--- a/buildSrc/src/main/kotlin/TypeDescriptorsTask.kt
+++ b/buildSrc/src/main/kotlin/TypeDescriptorsTask.kt
@@ -78,11 +78,10 @@ abstract class TypeDescriptorsTask @Inject constructor(
 
     @TaskAction
     fun exec() {
-        val lintFile = if (coreLibConfigJar.isPresent && apiLevel.isPresent) {
+        val lintFileUri = if (coreLibConfigJar.isPresent && apiLevel.isPresent) {
             selectLintFile(
                 coreLibConfigJar.get().singleFile,
-                apiLevel.get(),
-                temporaryDir
+                apiLevel.get()
             )
         } else {
             null
@@ -117,8 +116,8 @@ abstract class TypeDescriptorsTask @Inject constructor(
                         }
                     )
                 }
-                if (lintFile != null) {
-                    addAll(listOf("--lint-file", lintFile.path))
+                if (lintFileUri != null) {
+                    addAll(listOf("--lint-file", lintFileUri.toString()))
                 }
             }
         }

--- a/signature-builder/src/main/kotlin/com/toasttab/android/descriptors/AndroidTypeDescriptorBuilder.kt
+++ b/signature-builder/src/main/kotlin/com/toasttab/android/descriptors/AndroidTypeDescriptorBuilder.kt
@@ -28,6 +28,7 @@ import com.toasttab.expediter.types.ClassfileSource
 import com.toasttab.expediter.types.ClassfileSourceType
 import protokt.v1.toasttab.expediter.v1.TypeDescriptors
 import java.io.File
+import java.net.URI
 import java.util.zip.GZIPOutputStream
 
 class AndroidTypeDescriptorBuilder : CliktCommand() {
@@ -44,7 +45,7 @@ class AndroidTypeDescriptorBuilder : CliktCommand() {
     private val expediterOutput: String by option(help = "expediter-output").required()
 
     override fun run() {
-        val coreLibFilter = CoreLibFilter(lintFile?.let { File(it) })
+        val coreLibFilter = CoreLibFilter(lintFile?.let { URI(it) })
 
         val signatures =
             MutableTypeDescriptors(

--- a/signature-builder/src/main/kotlin/com/toasttab/android/descriptors/CoreLibFilter.kt
+++ b/signature-builder/src/main/kotlin/com/toasttab/android/descriptors/CoreLibFilter.kt
@@ -17,7 +17,7 @@ package com.toasttab.android.descriptors
 
 import protokt.v1.toasttab.expediter.v1.AccessProtection
 import protokt.v1.toasttab.expediter.v1.TypeDescriptor
-import java.io.File
+import java.net.URI
 
 /**
  * Filters and transforms core library desugaring types. Applies the following steps in order:
@@ -30,9 +30,9 @@ import java.io.File
  * Returns `null` if the type should be excluded entirely.
  */
 class CoreLibFilter(
-    lintFile: File?,
+    lintFileUri: URI?,
 ) {
-    private val lintFileFilter = lintFile?.let { LintFileFilter(it) }
+    private val lintFileFilter = lintFileUri?.let { LintFileFilter(it) }
 
     /**
      * Methods present in the core library desugaring jar that do not exist

--- a/signature-builder/src/main/kotlin/com/toasttab/android/descriptors/LintFileFilter.kt
+++ b/signature-builder/src/main/kotlin/com/toasttab/android/descriptors/LintFileFilter.kt
@@ -16,7 +16,7 @@
 package com.toasttab.android.descriptors
 
 import protokt.v1.toasttab.expediter.v1.TypeDescriptor
-import java.io.File
+import java.net.URI
 
 /**
  * Filters [TypeDescriptor] entries based on a desugared APIs lint file from the
@@ -28,7 +28,7 @@ import java.io.File
  * be excluded from the signature.
  */
 class LintFileFilter(
-    lintFile: File,
+    lintFileUri: URI,
 ) {
     /**
      * Classes listed without any member qualifiers (e.g. `java/util/Optional`). The entire
@@ -49,7 +49,7 @@ class LintFileFilter(
         val methods = mutableMapOf<String, MutableSet<String>>()
         val classesWithMembers = mutableSetOf<String>()
 
-        for (line in lintFile.readLines()) {
+        for (line in lintFileUri.toURL().readText().lines()) {
             val trimmed = line.trim()
             if (trimmed.isEmpty()) continue
 


### PR DESCRIPTION
## Summary
- `LintFileSelector` no longer extracts lint files into a temporary directory; it returns a `jar:` URI pointing directly into the config JAR
- `LintFileFilter` reads content via `URI.toURL().readText()`, eliminating the temp directory entirely
- Updated the full call chain: `TypeDescriptorsTask` → `AndroidTypeDescriptorBuilder` → `CoreLibFilter` → `LintFileFilter`

## Test plan
- [x] `./gradlew check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)