### PR TITLE
Add API levels 36 and 37

### DIFF
--- a/api/36/build.gradle.kts
+++ b/api/36/build.gradle.kts
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2026. Toast Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+plugins {
+    `signatures-conventions`
+}
+
+sdk("platform-36.1:r01")

--- a/api/36/src/test/java/com/toasttab/android/Api36DexTest.kt
+++ b/api/36/src/test/java/com/toasttab/android/Api36DexTest.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2026. Toast Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.toasttab.android
+
+import org.junit.jupiter.api.Test
+
+class Api36DexTest : BaseApiTest() {
+    @Test
+    fun `API36 desugaring should succeed`() {
+        testDesugaring(36)
+    }
+}

--- a/api/37/build.gradle.kts
+++ b/api/37/build.gradle.kts
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2026. Toast Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+plugins {
+    `signatures-conventions`
+}
+
+sdk("platform-37.0:r01")

--- a/api/37/src/test/java/com/toasttab/android/Api37DexTest.kt
+++ b/api/37/src/test/java/com/toasttab/android/Api37DexTest.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2026. Toast Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.toasttab.android
+
+import org.junit.jupiter.api.Test
+
+class Api37DexTest : BaseApiTest() {
+    @Test
+    fun `API37 desugaring should succeed`() {
+        testDesugaring(37)
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -58,6 +58,6 @@ include(
     "test:instrumented"
 )
 
-(19..35).forEach {
+(19..37).forEach {
     include("api:$it")
 }


### PR DESCRIPTION
## Summary
- Add signatures for API level 36 (`platform-36.1_r01`)
- Add signatures for API level 37 (`platform-37.0_r01`)

## Test plan
- [x] `./gradlew :api:36:buildSignatures :api:37:buildSignatures` succeeds
- [x] `./gradlew :api:36:check :api:37:check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)