### PR TITLE
Replace gradle-semantic-build-versioning with reckon

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -27,16 +27,16 @@ dependencyResolutionManagement {
     }
 }
 
-buildscript {
-    repositories {
-        gradlePluginPortal()
-    }
-    dependencies {
-        classpath("gradle.plugin.net.vivin:gradle-semantic-build-versioning:4.0.0")
-    }
+plugins {
+    id("org.ajoberstar.reckon.settings") version "2.0.0"
 }
 
-apply(plugin = "net.vivin.gradle-semantic-build-versioning")
+extensions.configure<org.ajoberstar.reckon.gradle.ReckonExtension> {
+    setDefaultInferredScope("patch")
+    snapshots()
+    setScopeCalc(calcScopeFromProp())
+    setStageCalc(calcStageFromProp())
+}
 
 rootProject.name = "gummybears"
 


### PR DESCRIPTION
## Summary
- Swaps the abandoned `gradle-semantic-build-versioning` plugin for `org.ajoberstar.reckon.settings` 2.0.0, mirroring the migration done in open-toast/expediter#255.
- Deletes the now-unused empty `semantic-build-versioning.gradle` config file.

## Test plan
- [x] Build resolves a SNAPSHOT version off an untagged HEAD (verified locally: `99.99.100-SNAPSHOT` after temporary `99.99.99` tag on prior commit).
- [x] Build resolves the exact tag as a release version when HEAD is annotated-tagged (verified locally: `99.99.99` across two runs with a temporary annotated tag on the branch HEAD; tag deleted afterward).
- [ ] CI `Build` workflow passes on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)